### PR TITLE
fix undefined symbol: __cpuid bug

### DIFF
--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -16,6 +16,9 @@
 #ifdef HAVE_SYS_AUXV_H
 #    include <sys/auxv.h>
 #endif
+#if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
+# include <intrin.h>
+#endif
 
 typedef struct CPUFeatures_ {
     int initialized;

--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -17,7 +17,7 @@
 #    include <sys/auxv.h>
 #endif
 #if defined(_MSC_VER) && (defined(_M_X64) || defined(_M_IX86))
-# include <intrin.h>
+#    include <intrin.h>
 #endif
 
 typedef struct CPUFeatures_ {


### PR DESCRIPTION
I think we need to add include <intrin.h> in cpu.c to avoid "undefined symbol: __cpuid" error from cpu.c::139. This should be the as issue as https://github.com/jedisct1/libsodium/issues/491