### PR TITLE
Add c++ guards

### DIFF
--- a/src/include/aegis.h
+++ b/src/include/aegis.h
@@ -17,6 +17,9 @@
 #include "aegis256x2.h"
 #include "aegis256x4.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
 /* Initialize the AEGIS library.
  *
  * This function does runtime CPU capability detection, and must be called once
@@ -43,5 +46,9 @@ int aegis_verify_16(const uint8_t *x, const uint8_t *y) __attribute__((warn_unus
  * Returns 0 if the blocks are equal, -1 otherwise.
  */
 int aegis_verify_32(const uint8_t *x, const uint8_t *y) __attribute__((warn_unused_result));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/include/aegis128l.h
+++ b/src/include/aegis128l.h
@@ -4,6 +4,11 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
 /* The length of an AEGIS key, in bytes */
 #define aegis128l_KEYBYTES 16
 
@@ -246,5 +251,8 @@ void aegis128l_encrypt_unauthenticated(uint8_t *c, const uint8_t *m, size_t mlen
  */
 void aegis128l_decrypt_unauthenticated(uint8_t *m, const uint8_t *c, size_t clen,
                                        const uint8_t *npub, const uint8_t *k);
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/include/aegis128x2.h
+++ b/src/include/aegis128x2.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The length of an AEGIS key, in bytes */
 #define aegis128x2_KEYBYTES 16
 
@@ -246,5 +250,9 @@ void aegis128x2_encrypt_unauthenticated(uint8_t *c, const uint8_t *m, size_t mle
  */
 void aegis128x2_decrypt_unauthenticated(uint8_t *m, const uint8_t *c, size_t clen,
                                         const uint8_t *npub, const uint8_t *k);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/include/aegis128x4.h
+++ b/src/include/aegis128x4.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The length of an AEGIS key, in bytes */
 #define aegis128x4_KEYBYTES 16
 
@@ -246,5 +250,9 @@ void aegis128x4_encrypt_unauthenticated(uint8_t *c, const uint8_t *m, size_t mle
  */
 void aegis128x4_decrypt_unauthenticated(uint8_t *m, const uint8_t *c, size_t clen,
                                         const uint8_t *npub, const uint8_t *k);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/include/aegis256.h
+++ b/src/include/aegis256.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The length of an AEGIS key, in bytes */
 #define aegis256_KEYBYTES 32
 
@@ -246,5 +250,9 @@ void aegis256_encrypt_unauthenticated(uint8_t *c, const uint8_t *m, size_t mlen,
  */
 void aegis256_decrypt_unauthenticated(uint8_t *m, const uint8_t *c, size_t clen,
                                       const uint8_t *npub, const uint8_t *k);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/include/aegis256x2.h
+++ b/src/include/aegis256x2.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The length of an AEGIS key, in bytes */
 #define aegis256x2_KEYBYTES 32
 
@@ -246,5 +250,9 @@ void aegis256x2_encrypt_unauthenticated(uint8_t *c, const uint8_t *m, size_t mle
  */
 void aegis256x2_decrypt_unauthenticated(uint8_t *m, const uint8_t *c, size_t clen,
                                         const uint8_t *npub, const uint8_t *k);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/src/include/aegis256x4.h
+++ b/src/include/aegis256x4.h
@@ -4,6 +4,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* The length of an AEGIS key, in bytes */
 #define aegis256x4_KEYBYTES 32
 
@@ -246,5 +250,9 @@ void aegis256x4_encrypt_unauthenticated(uint8_t *c, const uint8_t *m, size_t mle
  */
 void aegis256x4_decrypt_unauthenticated(uint8_t *m, const uint8_t *c, size_t clen,
                                         const uint8_t *npub, const uint8_t *k);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif


### PR DESCRIPTION
Ensures that when aegis public headers are included in a C++ context, that declared functions have C linkage.

```
// test.cc
#include <aegis.h>
int main() {
   return aegis_init();
}
```
```
c++ test.cc -laegis
```

now no longer fails with a linking error.