### PR TITLE
Undef HAVE_GETAUXVAL under old Android API versions

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -12,6 +12,9 @@
 #    define HAVE_GETAUXVAL
 #endif
 #ifdef __ANDROID_API__
+#    if __ANDROID_API__ < 18
+#        undef HAVE_GETAUXVAL
+#    endif
 #    define HAVE_ANDROID_GETCPUFEATURES
 #endif
 #if defined(__i386__) || defined(__x86_64__)


### PR DESCRIPTION
`getauxval` is only available on Android API levels >= 18: https://developer.android.com/ndk/guides/cpu-features.

sys/auxv.h in android is defined as:

```
unsigned long int getauxval(unsigned long int __type)
__INTRODUCED_IN(18)
```