### PR TITLE
Fix CPU architecture guards for x86 and x64 on MSVC

### DIFF
--- a/src/aegis128l/aegis128l.c
+++ b/src/aegis128l/aegis128l.c
@@ -185,7 +185,7 @@ aegis128l_pick_best_implementation(void)
     }
 #endif
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
     if (aegis_runtime_has_aesni() && aegis_runtime_has_avx()) {
         implementation = &aegis128l_aesni_implementation;
         return 0;

--- a/src/aegis128l/aegis128l_aesni.c
+++ b/src/aegis128l/aegis128l_aesni.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis128x2/aegis128x2.c
+++ b/src/aegis128x2/aegis128x2.c
@@ -186,7 +186,7 @@ aegis128x2_pick_best_implementation(void)
     }
 #endif
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx2()) {
         implementation = &aegis128x2_avx2_implementation;
         return 0;

--- a/src/aegis128x2/aegis128x2_aesni.c
+++ b/src/aegis128x2/aegis128x2_aesni.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis128x2/aegis128x2_avx2.c
+++ b/src/aegis128x2/aegis128x2_avx2.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis128x4/aegis128x4.c
+++ b/src/aegis128x4/aegis128x4.c
@@ -187,7 +187,7 @@ aegis128x4_pick_best_implementation(void)
     }
 #endif
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
 #    ifdef HAVE_VAESINTRIN_H
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx512f()) {
         implementation = &aegis128x4_avx512_implementation;

--- a/src/aegis128x4/aegis128x4_aesni.c
+++ b/src/aegis128x4/aegis128x4_aesni.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis128x4/aegis128x4_avx2.c
+++ b/src/aegis128x4/aegis128x4_avx2.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis128x4/aegis128x4_avx512.c
+++ b/src/aegis128x4/aegis128x4_avx512.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis256/aegis256.c
+++ b/src/aegis256/aegis256.c
@@ -185,7 +185,7 @@ aegis256_pick_best_implementation(void)
     }
 #endif
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
     if (aegis_runtime_has_aesni() && aegis_runtime_has_avx()) {
         implementation = &aegis256_aesni_implementation;
         return 0;

--- a/src/aegis256/aegis256_aesni.c
+++ b/src/aegis256/aegis256_aesni.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis256x2/aegis256x2.c
+++ b/src/aegis256x2/aegis256x2.c
@@ -186,7 +186,7 @@ aegis256x2_pick_best_implementation(void)
     }
 #endif
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx2()) {
         implementation = &aegis256x2_avx2_implementation;
         return 0;

--- a/src/aegis256x2/aegis256x2_aesni.c
+++ b/src/aegis256x2/aegis256x2_aesni.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis256x2/aegis256x2_avx2.c
+++ b/src/aegis256x2/aegis256x2_avx2.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis256x4/aegis256x4.c
+++ b/src/aegis256x4/aegis256x4.c
@@ -187,7 +187,7 @@ aegis256x4_pick_best_implementation(void)
     }
 #endif
 
-#if defined(__x86_64__) || defined(__i386__)
+#if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
 #    ifdef HAVE_VAESINTRIN_H
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx512f()) {
         implementation = &aegis256x4_avx512_implementation;

--- a/src/aegis256x4/aegis256x4_aesni.c
+++ b/src/aegis256x4/aegis256x4_aesni.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis256x4/aegis256x4_avx2.c
+++ b/src/aegis256x4/aegis256x4_avx2.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/aegis256x4/aegis256x4_avx512.c
+++ b/src/aegis256x4/aegis256x4_avx512.c
@@ -1,4 +1,4 @@
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 
 #    include <errno.h>
 #    include <stddef.h>

--- a/src/common/common.h
+++ b/src/common/common.h
@@ -14,14 +14,15 @@
 #ifdef __ANDROID_API__
 #    define HAVE_ANDROID_GETCPUFEATURES
 #endif
-#if defined(__i386__) || defined(__x86_64__)
+#if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
+
 #    define HAVE_CPUID
 #    define NATIVE_LITTLE_ENDIAN
 #    if defined(__clang__) || defined(__GNUC__)
 #        define HAVE_AVX_ASM
 #    endif
 #endif
-#ifdef __x86_64__
+#if defined(__x86_64__) || defined(_M_AMD64)
 #    define HAVE_AVXINTRIN_H
 #    define HAVE_AVX2INTRIN_H
 #    define HAVE_AVX512FINTRIN_H


### PR DESCRIPTION
I noticed that [rust-aegis](https://github.com/jedisct1/rust-aegis/) runs very slow when I build it with the MSVC toolchain on Windows. From what my online searches turned up, it looks like  MSVC uses `_M_IX86` and `_M_AMD64` for CPU architecture guards instead of `__i386__` and `__x86_64__` [^1].

This causes `libaegis` never to select any hardware accelerated implementations when built this way. I have created a simple test program that demonstrates the effect:

```bash
$ git clone --recursive https://github.com/mfrischknecht/rust-aegis-msvc-aesni-test.git
$ cd ./rust-aegis-msvc-aesni-test
$ git checkout without-fix
$ cargo run --release --quiet
CPU Features:

get_cpu_features(): 0
has_neon():         0
has_armcrypto():    0
has_avx():          0
has_avx2():         0
has_avx512f():      0
has_aesni():        0
has_vaes():         0

Encrypted: 100 MiB
Elapsed: 5.4909146s
Throughput: 18.211902257594755 MiB/s

$ git checkout with-fix
$ cargo run --release --quiet
CPU Features:

get_cpu_features(): 0
has_neon():         0
has_armcrypto():    0
has_avx():          1
has_avx2():         1
has_avx512f():      0
has_aesni():        1
has_vaes():         0

Encrypted: 100 MiB
Elapsed: 0.0278724s
Throughput: 3.5036900302808514 GiB/s
```

[^1]: See:
https://sourceforge.net/p/predef/wiki/Architectures/
http://web.archive.org/web/20240211072249/https://sourceforge.net/p/predef/wiki/Architectures/
https://archive.is/jRq9r