### PR TITLE
Add/expand compile guards for VAES (fixing MinGW cross compilation)

### DIFF
--- a/src/aegis128x2/aegis128x2.c
+++ b/src/aegis128x2/aegis128x2.c
@@ -187,10 +187,12 @@ aegis128x2_pick_best_implementation(void)
 #endif
 
 #if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
+#    ifdef HAVE_VAESINTRIN_H
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx2()) {
         implementation = &aegis128x2_avx2_implementation;
         return 0;
     }
+#    endif
     if (aegis_runtime_has_aesni() && aegis_runtime_has_avx()) {
         implementation = &aegis128x2_aesni_implementation;
         return 0;

--- a/src/aegis128x2/aegis128x2_avx2.c
+++ b/src/aegis128x2/aegis128x2_avx2.c
@@ -10,26 +10,28 @@
 #    include "aegis128x2.h"
 #    include "aegis128x2_avx2.h"
 
-#    ifdef __clang__
-#        pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
-#    elif defined(__GNUC__)
-#        pragma GCC target("vaes,avx2")
-#    endif
+#    ifdef HAVE_VAESINTRIN_H
 
-#    include <immintrin.h>
+#        ifdef __clang__
+#            pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
+#        elif defined(__GNUC__)
+#            pragma GCC target("vaes,avx2")
+#        endif
 
-#    define AES_BLOCK_LENGTH 32
+#        include <immintrin.h>
+
+#        define AES_BLOCK_LENGTH 32
 
 typedef __m256i aes_block_t;
 
-#    define AES_BLOCK_XOR(A, B) _mm256_xor_si256((A), (B))
-#    define AES_BLOCK_AND(A, B) _mm256_and_si256((A), (B))
-#    define AES_BLOCK_LOAD128_BROADCAST(A) \
-        _mm256_broadcastsi128_si256(_mm_loadu_si128((const void *) (A)))
-#    define AES_BLOCK_LOAD(A)         _mm256_loadu_si256((const aes_block_t *) (const void *) (A))
-#    define AES_BLOCK_LOAD_64x2(A, B) _mm256_broadcastsi128_si256(_mm_set_epi64x((A), (B)))
-#    define AES_BLOCK_STORE(A, B)     _mm256_storeu_si256((aes_block_t *) (void *) (A), (B))
-#    define AES_ENC(A, B)             _mm256_aesenc_epi128((A), (B))
+#        define AES_BLOCK_XOR(A, B) _mm256_xor_si256((A), (B))
+#        define AES_BLOCK_AND(A, B) _mm256_and_si256((A), (B))
+#        define AES_BLOCK_LOAD128_BROADCAST(A) \
+            _mm256_broadcastsi128_si256(_mm_loadu_si128((const void *) (A)))
+#        define AES_BLOCK_LOAD(A)         _mm256_loadu_si256((const aes_block_t *) (const void *) (A))
+#        define AES_BLOCK_LOAD_64x2(A, B) _mm256_broadcastsi128_si256(_mm_set_epi64x((A), (B)))
+#        define AES_BLOCK_STORE(A, B)     _mm256_storeu_si256((aes_block_t *) (void *) (A), (B))
+#        define AES_ENC(A, B)             _mm256_aesenc_epi128((A), (B))
 
 static inline void
 aegis128x2_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
@@ -50,7 +52,7 @@ aegis128x2_update(aes_block_t *const state, const aes_block_t d1, const aes_bloc
     state[4] = AES_BLOCK_XOR(state[4], d2);
 }
 
-#    include "aegis128x2_common.h"
+#        include "aegis128x2_common.h"
 
 struct aegis128x2_implementation aegis128x2_avx2_implementation = {
     .encrypt_detached              = encrypt_detached,
@@ -66,8 +68,10 @@ struct aegis128x2_implementation aegis128x2_avx2_implementation = {
     .state_decrypt_detached_final  = state_decrypt_detached_final,
 };
 
-#    ifdef __clang__
-#        pragma clang attribute pop
+#         ifdef __clang__
+#             pragma clang attribute pop
+#         endif
+
 #    endif
 
 #endif

--- a/src/aegis128x2/aegis128x2_avx2.h
+++ b/src/aegis128x2/aegis128x2_avx2.h
@@ -4,6 +4,8 @@
 #include "../common/common.h"
 #include "implementations.h"
 
+#ifdef HAVE_VAESINTRIN_H
 extern struct aegis128x2_implementation aegis128x2_avx2_implementation;
+#endif
 
 #endif

--- a/src/aegis128x4/aegis128x4.c
+++ b/src/aegis128x4/aegis128x4.c
@@ -193,11 +193,11 @@ aegis128x4_pick_best_implementation(void)
         implementation = &aegis128x4_avx512_implementation;
         return 0;
     }
-#    endif
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx2()) {
         implementation = &aegis128x4_avx2_implementation;
         return 0;
     }
+#    endif
     if (aegis_runtime_has_aesni() && aegis_runtime_has_avx()) {
         implementation = &aegis128x4_aesni_implementation;
         return 0;

--- a/src/aegis128x4/aegis128x4_avx2.c
+++ b/src/aegis128x4/aegis128x4_avx2.c
@@ -10,15 +10,17 @@
 #    include "aegis128x4.h"
 #    include "aegis128x4_avx2.h"
 
-#    ifdef __clang__
-#        pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
-#    elif defined(__GNUC__)
-#        pragma GCC target("vaes,avx2")
-#    endif
+#    ifdef HAVE_VAESINTRIN_H
 
-#    include <immintrin.h>
+#        ifdef __clang__
+#            pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
+#        elif defined(__GNUC__)
+#            pragma GCC target("vaes,avx2")
+#        endif
 
-#    define AES_BLOCK_LENGTH 64
+#        include <immintrin.h>
+
+#        define AES_BLOCK_LENGTH 64
 
 typedef struct {
     __m256i b0;
@@ -83,7 +85,7 @@ aegis128x4_update(aes_block_t *const state, const aes_block_t d1, const aes_bloc
     state[4] = AES_BLOCK_XOR(state[4], d2);
 }
 
-#    include "aegis128x4_common.h"
+#        include "aegis128x4_common.h"
 
 struct aegis128x4_implementation aegis128x4_avx2_implementation = {
     .encrypt_detached              = encrypt_detached,
@@ -99,8 +101,10 @@ struct aegis128x4_implementation aegis128x4_avx2_implementation = {
     .state_decrypt_detached_final  = state_decrypt_detached_final,
 };
 
-#    ifdef __clang__
-#        pragma clang attribute pop
+#        ifdef __clang__
+#            pragma clang attribute pop
+#        endif
+
 #    endif
 
 #endif

--- a/src/aegis128x4/aegis128x4_avx2.h
+++ b/src/aegis128x4/aegis128x4_avx2.h
@@ -4,6 +4,8 @@
 #include "../common/common.h"
 #include "implementations.h"
 
+#ifdef HAVE_VAESINTRIN_H
 extern struct aegis128x4_implementation aegis128x4_avx2_implementation;
+#endif
 
 #endif

--- a/src/aegis256x2/aegis256x2.c
+++ b/src/aegis256x2/aegis256x2.c
@@ -187,10 +187,12 @@ aegis256x2_pick_best_implementation(void)
 #endif
 
 #if defined(__x86_64__) || defined(_M_AMD64) || defined(__i386__) || defined(_M_IX86)
+#    ifdef HAVE_VAESINTRIN_H
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx2()) {
         implementation = &aegis256x2_avx2_implementation;
         return 0;
     }
+#    endif
     if (aegis_runtime_has_aesni() && aegis_runtime_has_avx()) {
         implementation = &aegis256x2_aesni_implementation;
         return 0;

--- a/src/aegis256x2/aegis256x2_avx2.c
+++ b/src/aegis256x2/aegis256x2_avx2.c
@@ -10,26 +10,28 @@
 #    include "aegis256x2.h"
 #    include "aegis256x2_avx2.h"
 
-#    ifdef __clang__
-#        pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
-#    elif defined(__GNUC__)
-#        pragma GCC target("vaes,avx2")
-#    endif
+#    ifdef HAVE_VAESINTRIN_H
 
-#    include <immintrin.h>
+#        ifdef __clang__
+#            pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
+#        elif defined(__GNUC__)
+#            pragma GCC target("vaes,avx2")
+#        endif
 
-#    define AES_BLOCK_LENGTH 32
+#        include <immintrin.h>
+
+#        define AES_BLOCK_LENGTH 32
 
 typedef __m256i aes_block_t;
 
-#    define AES_BLOCK_XOR(A, B) _mm256_xor_si256((A), (B))
-#    define AES_BLOCK_AND(A, B) _mm256_and_si256((A), (B))
-#    define AES_BLOCK_LOAD128_BROADCAST(A) \
-        _mm256_broadcastsi128_si256(_mm_loadu_si128((const void *) (A)))
-#    define AES_BLOCK_LOAD(A)         _mm256_loadu_si256((const aes_block_t *) (const void *) (A))
-#    define AES_BLOCK_LOAD_64x2(A, B) _mm256_broadcastsi128_si256(_mm_set_epi64x((A), (B)))
-#    define AES_BLOCK_STORE(A, B)     _mm256_storeu_si256((aes_block_t *) (void *) (A), (B))
-#    define AES_ENC(A, B)             _mm256_aesenc_epi128((A), (B))
+#        define AES_BLOCK_XOR(A, B) _mm256_xor_si256((A), (B))
+#        define AES_BLOCK_AND(A, B) _mm256_and_si256((A), (B))
+#        define AES_BLOCK_LOAD128_BROADCAST(A) \
+            _mm256_broadcastsi128_si256(_mm_loadu_si128((const void *) (A)))
+#        define AES_BLOCK_LOAD(A)         _mm256_loadu_si256((const aes_block_t *) (const void *) (A))
+#        define AES_BLOCK_LOAD_64x2(A, B) _mm256_broadcastsi128_si256(_mm_set_epi64x((A), (B)))
+#        define AES_BLOCK_STORE(A, B)     _mm256_storeu_si256((aes_block_t *) (void *) (A), (B))
+#        define AES_ENC(A, B)             _mm256_aesenc_epi128((A), (B))
 
 static inline void
 aegis256x2_update(aes_block_t *const state, const aes_block_t d)
@@ -45,7 +47,7 @@ aegis256x2_update(aes_block_t *const state, const aes_block_t d)
     state[0] = AES_BLOCK_XOR(AES_ENC(tmp, state[0]), d);
 }
 
-#    include "aegis256x2_common.h"
+#        include "aegis256x2_common.h"
 
 struct aegis256x2_implementation aegis256x2_avx2_implementation = {
     .encrypt_detached              = encrypt_detached,
@@ -61,8 +63,10 @@ struct aegis256x2_implementation aegis256x2_avx2_implementation = {
     .state_decrypt_detached_final  = state_decrypt_detached_final,
 };
 
-#    ifdef __clang__
-#        pragma clang attribute pop
+#        ifdef __clang__
+#            pragma clang attribute pop
+#        endif
+
 #    endif
 
 #endif

--- a/src/aegis256x2/aegis256x2_avx2.h
+++ b/src/aegis256x2/aegis256x2_avx2.h
@@ -4,6 +4,8 @@
 #include "../common/common.h"
 #include "implementations.h"
 
+#ifdef HAVE_VAESINTRIN_H
 extern struct aegis256x2_implementation aegis256x2_avx2_implementation;
+#endif
 
 #endif

--- a/src/aegis256x4/aegis256x4.c
+++ b/src/aegis256x4/aegis256x4.c
@@ -193,11 +193,11 @@ aegis256x4_pick_best_implementation(void)
         implementation = &aegis256x4_avx512_implementation;
         return 0;
     }
-#    endif
     if (aegis_runtime_has_vaes() && aegis_runtime_has_avx2()) {
         implementation = &aegis256x4_avx2_implementation;
         return 0;
     }
+#    endif
     if (aegis_runtime_has_aesni() && aegis_runtime_has_avx()) {
         implementation = &aegis256x4_aesni_implementation;
         return 0;

--- a/src/aegis256x4/aegis256x4_avx2.c
+++ b/src/aegis256x4/aegis256x4_avx2.c
@@ -10,15 +10,17 @@
 #    include "aegis256x4.h"
 #    include "aegis256x4_avx2.h"
 
-#    ifdef __clang__
-#        pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
-#    elif defined(__GNUC__)
-#        pragma GCC target("vaes,avx2")
-#    endif
+#    ifdef HAVE_VAESINTRIN_H
 
-#    include <immintrin.h>
+#        ifdef __clang__
+#            pragma clang attribute push(__attribute__((target("vaes,avx2"))), apply_to = function)
+#        elif defined(__GNUC__)
+#            pragma GCC target("vaes,avx2")
+#        endif
 
-#    define AES_BLOCK_LENGTH 64
+#        include <immintrin.h>
+
+#        define AES_BLOCK_LENGTH 64
 
 typedef struct {
     __m256i b0;
@@ -78,7 +80,7 @@ aegis256x4_update(aes_block_t *const state, const aes_block_t d)
     state[0] = AES_BLOCK_XOR(AES_ENC(tmp, state[0]), d);
 }
 
-#    include "aegis256x4_common.h"
+#        include "aegis256x4_common.h"
 
 struct aegis256x4_implementation aegis256x4_avx2_implementation = {
     .encrypt_detached              = encrypt_detached,
@@ -94,8 +96,10 @@ struct aegis256x4_implementation aegis256x4_avx2_implementation = {
     .state_decrypt_detached_final  = state_decrypt_detached_final,
 };
 
-#    ifdef __clang__
-#        pragma clang attribute pop
+#        ifdef __clang__
+#            pragma clang attribute pop
+#        endif
+
 #    endif
 
 #endif

--- a/src/aegis256x4/aegis256x4_avx2.h
+++ b/src/aegis256x4/aegis256x4_avx2.h
@@ -4,6 +4,8 @@
 #include "../common/common.h"
 #include "implementations.h"
 
+#ifdef HAVE_VAESINTRIN_H
 extern struct aegis256x4_implementation aegis256x4_avx2_implementation;
+#endif
 
 #endif


### PR DESCRIPTION
Some hardware accelerated implementations (e.g. aegis256x4_avx2) make use of `vaes` instructions without being gated behind `HAVE_VAESINTRIN_H`. This breaks cross compilation using rust's cross [^1] build tool (at least for Windows), presumably because the MinGW GCC implementation it packages doesn't support `vaes`.

This change introduces compile-time checks for `HAVE_VAESINTRIN_H` where they aren't present yet and extends some existing checks in some implementation picking functions (which would produce missing linker targets otherwise).

I also took the liberty to change the indentation for all nested pecompiler instructions where I added new #ifdef checks in the effort of keeping the overall code style in line with the other files; however, this makes the diff seem larger than it really is.

---

I've reused my test project for #8 in order to prepare another demonstration:

```
# Assuming `cross` is installed: cargo install cross

$ git clone --recursive https://github.com/mfrischknecht/rust-aegis-msvc-aesni-test.git
$ cd ./rust-aegis-msvc-aesni-test
$ git checkout without-fix
$ cross build --target=x86_64-pc-windows-gnu
[cross] warning: using newer rustc `1.77.2 (25ef9e3d8 2024-04-09)` for the target. Current active rustc on the host is `rustc 1.76.0 (07dca489a 2024-02-04)`.
 > Update with `rustup update`
   Compiling aegis v0.6.2 (https://github.com/mfrischknecht/rust-aegis.git?branch=debug#fc1cf867)
The following warnings were emitted during compilation:

warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:16:17: error: attribute(target("vaes")) is unknown
warning: aegis@0.6.2:  #        pragma GCC target("vaes,avx2")
warning: aegis@0.6.2:                  ^~~
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c: In function 'aegis128x2_update':
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:32:39: warning: implicit declaration of function '_mm256_aesenc_epi128'; did you mean '_mm256_bsrli_epi128'? [-Wimplicit-function-declaration]
warning: aegis@0.6.2:  #    define AES_ENC(A, B)             _mm256_aesenc_epi128((A), (B))
warning: aegis@0.6.2:                                        ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:40:16: note: in expansion of macro 'AES_ENC'
warning: aegis@0.6.2:      state[7] = AES_ENC(state[6], state[7]);
warning: aegis@0.6.2:                 ^~~~~~~
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:40:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[7] = AES_ENC(state[6], state[7]);
warning: aegis@0.6.2:               ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:41:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[6] = AES_ENC(state[5], state[6]);
warning: aegis@0.6.2:               ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:42:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[5] = AES_ENC(state[4], state[5]);
warning: aegis@0.6.2:               ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:43:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[4] = AES_ENC(state[3], state[4]);
warning: aegis@0.6.2:               ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:44:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[3] = AES_ENC(state[2], state[3]);
warning: aegis@0.6.2:               ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:45:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[2] = AES_ENC(state[1], state[2]);
warning: aegis@0.6.2:               ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:46:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[1] = AES_ENC(state[0], state[1]);
warning: aegis@0.6.2:               ^
warning: aegis@0.6.2: src/c/libaegis/src/aegis128x2/aegis128x2_avx2.c:47:14: error: incompatible types when assigning to type 'aes_block_t {aka __vector(4) long long int}' from type 'int'
warning: aegis@0.6.2:      state[0] = AES_ENC(tmp, state[0]);
warning: aegis@0.6.2:               ^

error: failed to run custom build command for `aegis v0.6.2 (https://github.com/mfrischknecht/rust-aegis.git?branch=debug#fc1cf867)`

Caused by:
  process didn't exit successfully: `/target/debug/build/aegis-cc75870d99de2ece/build-script-build` (exit status: 1)
  --- stdout
...and so on and so forth




$ git checkout with-cross-fix
$ cross build --target=x86_64-pc-windows-gnu
[cross] warning: using newer rustc `1.77.2 (25ef9e3d8 2024-04-09)` for the target. Current active rustc on the host is `rustc 1.76.0 (07dca489a 2024-02-04)`.
 > Update with `rustup update`
   Compiling cfg-if v1.0.0
   Compiling cc v1.0.95
   Compiling ppv-lite86 v0.2.17
   Compiling softaes v0.1.3
   Compiling getrandom v0.2.14
   Compiling rand_core v0.6.4
   Compiling rand_chacha v0.3.1
   Compiling aegis v0.6.3 (https://github.com/mfrischknecht/rust-aegis.git?branch=fix-rust-cross-mingw-compilation#d334ccd4)
   Compiling rand v0.8.5
   Compiling rust-aegis-test v0.1.0 (/project)
    Finished dev [unoptimized + debuginfo] target(s) in 1m 59s
```

[^1]: https://github.com/cross-rs/cross