### PR TITLE
CI: also run on arm64

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,13 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -11,7 +11,13 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+
+    runs-on: ${{ matrix.os }}
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Github now has arm64 runners, let's use them to run the compilaton and test on arm64 in addition to x86_64.

Note: there is no "ubuntu-latest-arm" [1], so I used the latest arm64 image as of this writing, which
is ubuntu-24.04-arm.

[1] https://github.com/orgs/community/discussions/148648#discussioncomment-11858187