### PR TITLE
Rename "armcrypto" implementations to "neon_aes"

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -31,14 +31,14 @@ pub fn build(b: *std.Build) void {
     const source_files = &.{
         "src/aegis128l/aegis128l_aesni.c",
         "src/aegis128l/aegis128l_altivec.c",
-        "src/aegis128l/aegis128l_armcrypto.c",
+        "src/aegis128l/aegis128l_neon_aes.c",
         "src/aegis128l/aegis128l_soft.c",
         "src/aegis128l/aegis128l.c",
 
         "src/aegis128x2/aegis128x2_aesni.c",
         "src/aegis128x2/aegis128x2_altivec.c",
         "src/aegis128x2/aegis128x2_avx2.c",
-        "src/aegis128x2/aegis128x2_armcrypto.c",
+        "src/aegis128x2/aegis128x2_neon_aes.c",
         "src/aegis128x2/aegis128x2_soft.c",
         "src/aegis128x2/aegis128x2.c",
 
@@ -46,21 +46,21 @@ pub fn build(b: *std.Build) void {
         "src/aegis128x4/aegis128x4_altivec.c",
         "src/aegis128x4/aegis128x4_avx2.c",
         "src/aegis128x4/aegis128x4_avx512.c",
-        "src/aegis128x4/aegis128x4_armcrypto.c",
-        "src/aegis128x4/aegis128x4_armcrypto.c",
+        "src/aegis128x4/aegis128x4_neon_aes.c",
+        "src/aegis128x4/aegis128x4_neon_aes.c",
         "src/aegis128x4/aegis128x4_soft.c",
         "src/aegis128x4/aegis128x4.c",
 
         "src/aegis256/aegis256_aesni.c",
         "src/aegis256/aegis256_altivec.c",
-        "src/aegis256/aegis256_armcrypto.c",
+        "src/aegis256/aegis256_neon_aes.c",
         "src/aegis256/aegis256_soft.c",
         "src/aegis256/aegis256.c",
 
         "src/aegis256x2/aegis256x2_aesni.c",
         "src/aegis256x2/aegis256x2_altivec.c",
         "src/aegis256x2/aegis256x2_avx2.c",
-        "src/aegis256x2/aegis256x2_armcrypto.c",
+        "src/aegis256x2/aegis256x2_neon_aes.c",
         "src/aegis256x2/aegis256x2_soft.c",
         "src/aegis256x2/aegis256x2.c",
 
@@ -68,7 +68,7 @@ pub fn build(b: *std.Build) void {
         "src/aegis256x4/aegis256x4_altivec.c",
         "src/aegis256x4/aegis256x4_avx2.c",
         "src/aegis256x4/aegis256x4_avx512.c",
-        "src/aegis256x4/aegis256x4_armcrypto.c",
+        "src/aegis256x4/aegis256x4_neon_aes.c",
         "src/aegis256x4/aegis256x4_soft.c",
         "src/aegis256x4/aegis256x4.c",
 

--- a/src/aegis128l/aegis128l.c
+++ b/src/aegis128l/aegis128l.c
@@ -6,14 +6,14 @@
 #include "aegis128l.h"
 #include "aegis128l_aesni.h"
 #include "aegis128l_altivec.h"
-#include "aegis128l_armcrypto.h"
+#include "aegis128l_neon_aes.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis128l_soft.h"
 static const aegis128l_implementation *implementation = &aegis128l_soft_implementation;
 #else
 #    if defined(__aarch64__) || defined(_M_ARM64)
-static const aegis128l_implementation *implementation = &aegis128l_armcrypto_implementation;
+static const aegis128l_implementation *implementation = &aegis128l_neon_aes_implementation;
 #    elif defined(__x86_64__) || defined(__i386__)
 static const aegis128l_implementation *implementation = &aegis128l_aesni_implementation;
 #    elif defined(__ALTIVEC__) && defined(__CRYPTO__)
@@ -232,8 +232,8 @@ aegis128l_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-    if (aegis_runtime_has_armcrypto()) {
-        implementation = &aegis128l_armcrypto_implementation;
+    if (aegis_runtime_has_neon_aes()) {
+        implementation = &aegis128l_neon_aes_implementation;
         return 0;
     }
 #endif

--- a/src/aegis128l/aegis128l_armcrypto.h
+++ b/src/aegis128l/aegis128l_armcrypto.h
@@ -1,9 +1,0 @@
-#ifndef aegis128l_armcrypto_H
-#define aegis128l_armcrypto_H
-
-#include "../common/common.h"
-#include "implementations.h"
-
-extern struct aegis128l_implementation aegis128l_armcrypto_implementation;
-
-#endif

--- a/src/aegis128l/aegis128l_neon_aes.c
+++ b/src/aegis128l/aegis128l_neon_aes.c
@@ -5,7 +5,7 @@
 
 #    include "../common/common.h"
 #    include "aegis128l.h"
-#    include "aegis128l_armcrypto.h"
+#    include "aegis128l_neon_aes.h"
 
 #    ifndef __ARM_FEATURE_CRYPTO
 #        define __ARM_FEATURE_CRYPTO 1
@@ -52,7 +52,7 @@ aegis128l_update(aes_block_t *const state, const aes_block_t d1, const aes_block
 
 #    include "aegis128l_common.h"
 
-struct aegis128l_implementation aegis128l_armcrypto_implementation = {
+struct aegis128l_implementation aegis128l_neon_aes_implementation = {
     .encrypt_detached              = encrypt_detached,
     .decrypt_detached              = decrypt_detached,
     .encrypt_unauthenticated       = encrypt_unauthenticated,

--- a/src/aegis128l/aegis128l_neon_aes.h
+++ b/src/aegis128l/aegis128l_neon_aes.h
@@ -1,0 +1,9 @@
+#ifndef aegis128l_neon_aes_H
+#define aegis128l_neon_aes_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis128l_implementation aegis128l_neon_aes_implementation;
+
+#endif

--- a/src/aegis128x2/aegis128x2.c
+++ b/src/aegis128x2/aegis128x2.c
@@ -6,7 +6,7 @@
 #include "aegis128x2.h"
 #include "aegis128x2_aesni.h"
 #include "aegis128x2_altivec.h"
-#include "aegis128x2_armcrypto.h"
+#include "aegis128x2_neon_aes.h"
 #include "aegis128x2_avx2.h"
 
 #ifndef HAS_HW_AES
@@ -14,7 +14,7 @@
 static const aegis128x2_implementation *implementation = &aegis128x2_soft_implementation;
 #else
 #    if defined(__aarch64__) || defined(_M_ARM64)
-static const aegis128x2_implementation *implementation = &aegis128x2_armcrypto_implementation;
+static const aegis128x2_implementation *implementation = &aegis128x2_neon_aes_implementation;
 #    elif defined(__x86_64__) || defined(__i386__)
 static const aegis128x2_implementation *implementation = &aegis128x2_aesni_implementation;
 #    elif defined(__ALTIVEC__) && defined(__CRYPTO__)
@@ -232,8 +232,8 @@ aegis128x2_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-    if (aegis_runtime_has_armcrypto()) {
-        implementation = &aegis128x2_armcrypto_implementation;
+    if (aegis_runtime_has_neon_aes()) {
+        implementation = &aegis128x2_neon_aes_implementation;
         return 0;
     }
 #endif

--- a/src/aegis128x2/aegis128x2_armcrypto.h
+++ b/src/aegis128x2/aegis128x2_armcrypto.h
@@ -1,9 +1,0 @@
-#ifndef aegis128x2_armcrypto_H
-#define aegis128x2_armcrypto_H
-
-#include "../common/common.h"
-#include "implementations.h"
-
-extern struct aegis128x2_implementation aegis128x2_armcrypto_implementation;
-
-#endif

--- a/src/aegis128x2/aegis128x2_neon_aes.c
+++ b/src/aegis128x2/aegis128x2_neon_aes.c
@@ -4,8 +4,8 @@
 #    include <stdint.h>
 
 #    include "../common/common.h"
-#    include "aegis256x4.h"
-#    include "aegis256x4_armcrypto.h"
+#    include "aegis128x2.h"
+#    include "aegis128x2_neon_aes.h"
 
 #    ifndef __ARM_FEATURE_CRYPTO
 #        define __ARM_FEATURE_CRYPTO 1
@@ -23,76 +23,70 @@
 #        pragma GCC target("+simd+crypto")
 #    endif
 
-#    define AES_BLOCK_LENGTH 64
+#    define AES_BLOCK_LENGTH 32
 
 typedef struct {
     uint8x16_t b0;
     uint8x16_t b1;
-    uint8x16_t b2;
-    uint8x16_t b3;
 } aes_block_t;
 
 static inline aes_block_t
 AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
 {
-    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1), veorq_u8(a.b2, b.b2),
-                           veorq_u8(a.b3, b.b3) };
+    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1) };
 }
 
 static inline aes_block_t
 AES_BLOCK_AND(const aes_block_t a, const aes_block_t b)
 {
-    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1), vandq_u8(a.b2, b.b2),
-                           vandq_u8(a.b3, b.b3) };
+    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1) };
 }
 
 static inline aes_block_t
 AES_BLOCK_LOAD(const uint8_t *a)
 {
-    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16), vld1q_u8(a + 32), vld1q_u8(a + 48) };
+    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16) };
 }
 
 static inline aes_block_t
 AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
 {
     const uint8x16_t t = vreinterpretq_u8_u64(vsetq_lane_u64((a), vmovq_n_u64(b), 1));
-    return (aes_block_t) { t, t, t, t };
+    return (aes_block_t) { t, t };
 }
 static inline void
 AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
 {
     vst1q_u8(a, b.b0);
     vst1q_u8(a + 16, b.b1);
-    vst1q_u8(a + 32, b.b2);
-    vst1q_u8(a + 48, b.b3);
 }
 
 static inline aes_block_t
 AES_ENC(const aes_block_t a, const aes_block_t b)
 {
     return (aes_block_t) { veorq_u8(vaesmcq_u8(vaeseq_u8((a.b0), vmovq_n_u8(0))), (b.b0)),
-                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b1), vmovq_n_u8(0))), (b.b1)),
-                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b2), vmovq_n_u8(0))), (b.b2)),
-                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b3), vmovq_n_u8(0))), (b.b3)) };
+                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b1), vmovq_n_u8(0))), (b.b1)) };
 }
 
 static inline void
-aegis256x4_update(aes_block_t *const state, const aes_block_t d)
+aegis128x2_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
 {
     aes_block_t tmp;
 
-    tmp      = state[5];
+    tmp      = state[7];
+    state[7] = AES_ENC(state[6], state[7]);
+    state[6] = AES_ENC(state[5], state[6]);
     state[5] = AES_ENC(state[4], state[5]);
-    state[4] = AES_ENC(state[3], state[4]);
+    state[4] = AES_BLOCK_XOR(AES_ENC(state[3], state[4]), d2);
     state[3] = AES_ENC(state[2], state[3]);
     state[2] = AES_ENC(state[1], state[2]);
     state[1] = AES_ENC(state[0], state[1]);
-    state[0] = AES_BLOCK_XOR(AES_ENC(tmp, state[0]), d);
+    state[0] = AES_BLOCK_XOR(AES_ENC(tmp, state[0]), d1);
 }
 
-#    include "aegis256x4_common.h"
+#    include "aegis128x2_common.h"
 
-struct aegis256x4_implementation aegis256x4_armcrypto_implementation = {
+struct aegis128x2_implementation aegis128x2_neon_aes_implementation = {
     .encrypt_detached              = encrypt_detached,
     .decrypt_detached              = decrypt_detached,
     .encrypt_unauthenticated       = encrypt_unauthenticated,

--- a/src/aegis128x2/aegis128x2_neon_aes.h
+++ b/src/aegis128x2/aegis128x2_neon_aes.h
@@ -1,0 +1,9 @@
+#ifndef aegis128x2_neon_aes_H
+#define aegis128x2_neon_aes_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis128x2_implementation aegis128x2_neon_aes_implementation;
+
+#endif

--- a/src/aegis128x4/aegis128x4.c
+++ b/src/aegis128x4/aegis128x4.c
@@ -6,7 +6,7 @@
 #include "aegis128x4.h"
 #include "aegis128x4_aesni.h"
 #include "aegis128x4_altivec.h"
-#include "aegis128x4_armcrypto.h"
+#include "aegis128x4_neon_aes.h"
 #include "aegis128x4_avx2.h"
 #include "aegis128x4_avx512.h"
 
@@ -15,7 +15,7 @@
 static const aegis128x4_implementation *implementation = &aegis128x4_soft_implementation;
 #else
 #    if defined(__aarch64__) || defined(_M_ARM64)
-static const aegis128x4_implementation *implementation = &aegis128x4_armcrypto_implementation;
+static const aegis128x4_implementation *implementation = &aegis128x4_neon_aes_implementation;
 #    elif defined(__x86_64__) || defined(__i386__)
 static const aegis128x4_implementation *implementation = &aegis128x4_aesni_implementation;
 #    elif defined(__ALTIVEC__) && defined(__CRYPTO__)
@@ -233,8 +233,8 @@ aegis128x4_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-    if (aegis_runtime_has_armcrypto()) {
-        implementation = &aegis128x4_armcrypto_implementation;
+    if (aegis_runtime_has_neon_aes()) {
+        implementation = &aegis128x4_neon_aes_implementation;
         return 0;
     }
 #endif

--- a/src/aegis128x4/aegis128x4_armcrypto.h
+++ b/src/aegis128x4/aegis128x4_armcrypto.h
@@ -1,9 +1,0 @@
-#ifndef aegis128x4_armcrypto_H
-#define aegis128x4_armcrypto_H
-
-#include "../common/common.h"
-#include "implementations.h"
-
-extern struct aegis128x4_implementation aegis128x4_armcrypto_implementation;
-
-#endif

--- a/src/aegis128x4/aegis128x4_neon_aes.c
+++ b/src/aegis128x4/aegis128x4_neon_aes.c
@@ -5,7 +5,7 @@
 
 #    include "../common/common.h"
 #    include "aegis128x4.h"
-#    include "aegis128x4_armcrypto.h"
+#    include "aegis128x4_neon_aes.h"
 
 #    ifndef __ARM_FEATURE_CRYPTO
 #        define __ARM_FEATURE_CRYPTO 1
@@ -94,7 +94,7 @@ aegis128x4_update(aes_block_t *const state, const aes_block_t d1, const aes_bloc
 
 #    include "aegis128x4_common.h"
 
-struct aegis128x4_implementation aegis128x4_armcrypto_implementation = {
+struct aegis128x4_implementation aegis128x4_neon_aes_implementation = {
     .encrypt_detached              = encrypt_detached,
     .decrypt_detached              = decrypt_detached,
     .encrypt_unauthenticated       = encrypt_unauthenticated,

--- a/src/aegis128x4/aegis128x4_neon_aes.h
+++ b/src/aegis128x4/aegis128x4_neon_aes.h
@@ -1,0 +1,9 @@
+#ifndef aegis128x4_neon_aes_H
+#define aegis128x4_neon_aes_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis128x4_implementation aegis128x4_neon_aes_implementation;
+
+#endif

--- a/src/aegis256/aegis256.c
+++ b/src/aegis256/aegis256.c
@@ -6,14 +6,14 @@
 #include "aegis256.h"
 #include "aegis256_aesni.h"
 #include "aegis256_altivec.h"
-#include "aegis256_armcrypto.h"
+#include "aegis256_neon_aes.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis256_soft.h"
 static const aegis256_implementation *implementation = &aegis256_soft_implementation;
 #else
 #    if defined(__aarch64__) || defined(_M_ARM64)
-static const aegis256_implementation *implementation = &aegis256_armcrypto_implementation;
+static const aegis256_implementation *implementation = &aegis256_neon_aes_implementation;
 #    elif defined(__x86_64__) || defined(__i386__)
 static const aegis256_implementation *implementation = &aegis256_aesni_implementation;
 #    elif defined(__ALTIVEC__) && defined(__CRYPTO__)
@@ -231,8 +231,8 @@ aegis256_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-    if (aegis_runtime_has_armcrypto()) {
-        implementation = &aegis256_armcrypto_implementation;
+    if (aegis_runtime_has_neon_aes()) {
+        implementation = &aegis256_neon_aes_implementation;
         return 0;
     }
 #endif

--- a/src/aegis256/aegis256_armcrypto.h
+++ b/src/aegis256/aegis256_armcrypto.h
@@ -1,9 +1,0 @@
-#ifndef aegis256_armcrypto_H
-#define aegis256_armcrypto_H
-
-#include "../common/common.h"
-#include "implementations.h"
-
-extern struct aegis256_implementation aegis256_armcrypto_implementation;
-
-#endif

--- a/src/aegis256/aegis256_neon_aes.c
+++ b/src/aegis256/aegis256_neon_aes.c
@@ -5,7 +5,7 @@
 
 #    include "../common/common.h"
 #    include "aegis256.h"
-#    include "aegis256_armcrypto.h"
+#    include "aegis256_neon_aes.h"
 
 #    ifndef __ARM_FEATURE_CRYPTO
 #        define __ARM_FEATURE_CRYPTO 1
@@ -50,7 +50,7 @@ aegis256_update(aes_block_t *const state, const aes_block_t d)
 
 #    include "aegis256_common.h"
 
-struct aegis256_implementation aegis256_armcrypto_implementation = {
+struct aegis256_implementation aegis256_neon_aes_implementation = {
     .encrypt_detached              = encrypt_detached,
     .decrypt_detached              = decrypt_detached,
     .encrypt_unauthenticated       = encrypt_unauthenticated,

--- a/src/aegis256/aegis256_neon_aes.h
+++ b/src/aegis256/aegis256_neon_aes.h
@@ -1,0 +1,9 @@
+#ifndef aegis256_neon_aes_H
+#define aegis256_neon_aes_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis256_implementation aegis256_neon_aes_implementation;
+
+#endif

--- a/src/aegis256x2/aegis256x2.c
+++ b/src/aegis256x2/aegis256x2.c
@@ -6,7 +6,7 @@
 #include "aegis256x2.h"
 #include "aegis256x2_aesni.h"
 #include "aegis256x2_altivec.h"
-#include "aegis256x2_armcrypto.h"
+#include "aegis256x2_neon_aes.h"
 #include "aegis256x2_avx2.h"
 
 #ifndef HAS_HW_AES
@@ -14,7 +14,7 @@
 static const aegis256x2_implementation *implementation = &aegis256x2_soft_implementation;
 #else
 #    if defined(__aarch64__) || defined(_M_ARM64)
-static const aegis256x2_implementation *implementation = &aegis256x2_armcrypto_implementation;
+static const aegis256x2_implementation *implementation = &aegis256x2_neon_aes_implementation;
 #    elif defined(__x86_64__) || defined(__i386__)
 static const aegis256x2_implementation *implementation = &aegis256x2_aesni_implementation;
 #    elif defined(__ALTIVEC__) && defined(__CRYPTO__)
@@ -232,8 +232,8 @@ aegis256x2_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-    if (aegis_runtime_has_armcrypto()) {
-        implementation = &aegis256x2_armcrypto_implementation;
+    if (aegis_runtime_has_neon_aes()) {
+        implementation = &aegis256x2_neon_aes_implementation;
         return 0;
     }
 #endif

--- a/src/aegis256x2/aegis256x2_armcrypto.h
+++ b/src/aegis256x2/aegis256x2_armcrypto.h
@@ -1,9 +1,0 @@
-#ifndef aegis256x2_armcrypto_H
-#define aegis256x2_armcrypto_H
-
-#include "../common/common.h"
-#include "implementations.h"
-
-extern struct aegis256x2_implementation aegis256x2_armcrypto_implementation;
-
-#endif

--- a/src/aegis256x2/aegis256x2_neon_aes.c
+++ b/src/aegis256x2/aegis256x2_neon_aes.c
@@ -4,8 +4,8 @@
 #    include <stdint.h>
 
 #    include "../common/common.h"
-#    include "aegis128x2.h"
-#    include "aegis128x2_armcrypto.h"
+#    include "aegis256x2.h"
+#    include "aegis256x2_neon_aes.h"
 
 #    ifndef __ARM_FEATURE_CRYPTO
 #        define __ARM_FEATURE_CRYPTO 1
@@ -69,24 +69,22 @@ AES_ENC(const aes_block_t a, const aes_block_t b)
 }
 
 static inline void
-aegis128x2_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
+aegis256x2_update(aes_block_t *const state, const aes_block_t d)
 {
     aes_block_t tmp;
 
-    tmp      = state[7];
-    state[7] = AES_ENC(state[6], state[7]);
-    state[6] = AES_ENC(state[5], state[6]);
+    tmp      = state[5];
     state[5] = AES_ENC(state[4], state[5]);
-    state[4] = AES_BLOCK_XOR(AES_ENC(state[3], state[4]), d2);
+    state[4] = AES_ENC(state[3], state[4]);
     state[3] = AES_ENC(state[2], state[3]);
     state[2] = AES_ENC(state[1], state[2]);
     state[1] = AES_ENC(state[0], state[1]);
-    state[0] = AES_BLOCK_XOR(AES_ENC(tmp, state[0]), d1);
+    state[0] = AES_BLOCK_XOR(AES_ENC(tmp, state[0]), d);
 }
 
-#    include "aegis128x2_common.h"
+#    include "aegis256x2_common.h"
 
-struct aegis128x2_implementation aegis128x2_armcrypto_implementation = {
+struct aegis256x2_implementation aegis256x2_neon_aes_implementation = {
     .encrypt_detached              = encrypt_detached,
     .decrypt_detached              = decrypt_detached,
     .encrypt_unauthenticated       = encrypt_unauthenticated,

--- a/src/aegis256x2/aegis256x2_neon_aes.h
+++ b/src/aegis256x2/aegis256x2_neon_aes.h
@@ -1,0 +1,9 @@
+#ifndef aegis256x2_neon_aes_H
+#define aegis256x2_neon_aes_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis256x2_implementation aegis256x2_neon_aes_implementation;
+
+#endif

--- a/src/aegis256x4/aegis256x4.c
+++ b/src/aegis256x4/aegis256x4.c
@@ -6,7 +6,7 @@
 #include "aegis256x4.h"
 #include "aegis256x4_aesni.h"
 #include "aegis256x4_altivec.h"
-#include "aegis256x4_armcrypto.h"
+#include "aegis256x4_neon_aes.h"
 #include "aegis256x4_avx2.h"
 #include "aegis256x4_avx512.h"
 
@@ -15,7 +15,7 @@
 static const aegis256x4_implementation *implementation = &aegis256x4_soft_implementation;
 #else
 #    if defined(__aarch64__) || defined(_M_ARM64)
-static const aegis256x4_implementation *implementation = &aegis256x4_armcrypto_implementation;
+static const aegis256x4_implementation *implementation = &aegis256x4_neon_aes_implementation;
 #    elif defined(__x86_64__) || defined(__i386__)
 static const aegis256x4_implementation *implementation = &aegis256x4_aesni_implementation;
 #    elif defined(__ALTIVEC__) && defined(__CRYPTO__)
@@ -233,8 +233,8 @@ aegis256x4_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
-    if (aegis_runtime_has_armcrypto()) {
-        implementation = &aegis256x4_armcrypto_implementation;
+    if (aegis_runtime_has_neon_aes()) {
+        implementation = &aegis256x4_neon_aes_implementation;
         return 0;
     }
 #endif

--- a/src/aegis256x4/aegis256x4_armcrypto.h
+++ b/src/aegis256x4/aegis256x4_armcrypto.h
@@ -1,9 +1,0 @@
-#ifndef aegis256x4_armcrypto_H
-#define aegis256x4_armcrypto_H
-
-#include "../common/common.h"
-#include "implementations.h"
-
-extern struct aegis256x4_implementation aegis256x4_armcrypto_implementation;
-
-#endif

--- a/src/aegis256x4/aegis256x4_neon_aes.c
+++ b/src/aegis256x4/aegis256x4_neon_aes.c
@@ -4,8 +4,8 @@
 #    include <stdint.h>
 
 #    include "../common/common.h"
-#    include "aegis256x2.h"
-#    include "aegis256x2_armcrypto.h"
+#    include "aegis256x4.h"
+#    include "aegis256x4_neon_aes.h"
 
 #    ifndef __ARM_FEATURE_CRYPTO
 #        define __ARM_FEATURE_CRYPTO 1
@@ -23,53 +23,61 @@
 #        pragma GCC target("+simd+crypto")
 #    endif
 
-#    define AES_BLOCK_LENGTH 32
+#    define AES_BLOCK_LENGTH 64
 
 typedef struct {
     uint8x16_t b0;
     uint8x16_t b1;
+    uint8x16_t b2;
+    uint8x16_t b3;
 } aes_block_t;
 
 static inline aes_block_t
 AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
 {
-    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1) };
+    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1), veorq_u8(a.b2, b.b2),
+                           veorq_u8(a.b3, b.b3) };
 }
 
 static inline aes_block_t
 AES_BLOCK_AND(const aes_block_t a, const aes_block_t b)
 {
-    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1) };
+    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1), vandq_u8(a.b2, b.b2),
+                           vandq_u8(a.b3, b.b3) };
 }
 
 static inline aes_block_t
 AES_BLOCK_LOAD(const uint8_t *a)
 {
-    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16) };
+    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16), vld1q_u8(a + 32), vld1q_u8(a + 48) };
 }
 
 static inline aes_block_t
 AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
 {
     const uint8x16_t t = vreinterpretq_u8_u64(vsetq_lane_u64((a), vmovq_n_u64(b), 1));
-    return (aes_block_t) { t, t };
+    return (aes_block_t) { t, t, t, t };
 }
 static inline void
 AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
 {
     vst1q_u8(a, b.b0);
     vst1q_u8(a + 16, b.b1);
+    vst1q_u8(a + 32, b.b2);
+    vst1q_u8(a + 48, b.b3);
 }
 
 static inline aes_block_t
 AES_ENC(const aes_block_t a, const aes_block_t b)
 {
     return (aes_block_t) { veorq_u8(vaesmcq_u8(vaeseq_u8((a.b0), vmovq_n_u8(0))), (b.b0)),
-                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b1), vmovq_n_u8(0))), (b.b1)) };
+                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b1), vmovq_n_u8(0))), (b.b1)),
+                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b2), vmovq_n_u8(0))), (b.b2)),
+                           veorq_u8(vaesmcq_u8(vaeseq_u8((a.b3), vmovq_n_u8(0))), (b.b3)) };
 }
 
 static inline void
-aegis256x2_update(aes_block_t *const state, const aes_block_t d)
+aegis256x4_update(aes_block_t *const state, const aes_block_t d)
 {
     aes_block_t tmp;
 
@@ -82,9 +90,9 @@ aegis256x2_update(aes_block_t *const state, const aes_block_t d)
     state[0] = AES_BLOCK_XOR(AES_ENC(tmp, state[0]), d);
 }
 
-#    include "aegis256x2_common.h"
+#    include "aegis256x4_common.h"
 
-struct aegis256x2_implementation aegis256x2_armcrypto_implementation = {
+struct aegis256x4_implementation aegis256x4_neon_aes_implementation = {
     .encrypt_detached              = encrypt_detached,
     .decrypt_detached              = decrypt_detached,
     .encrypt_unauthenticated       = encrypt_unauthenticated,

--- a/src/aegis256x4/aegis256x4_neon_aes.h
+++ b/src/aegis256x4/aegis256x4_neon_aes.h
@@ -1,0 +1,9 @@
+#ifndef aegis256x4_neon_aes_H
+#define aegis256x4_neon_aes_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis256x4_implementation aegis256x4_neon_aes_implementation;
+
+#endif

--- a/src/common/cpu.c
+++ b/src/common/cpu.c
@@ -22,7 +22,7 @@
 typedef struct CPUFeatures_ {
     int initialized;
     int has_neon;
-    int has_armcrypto;
+    int has_neon_aes;
     int has_avx;
     int has_avx2;
     int has_avx512f;
@@ -88,9 +88,9 @@ _runtime_arm_cpu_features(CPUFeatures *const cpu_features)
     }
 
 #if __ARM_FEATURE_CRYPTO
-    cpu_features->has_armcrypto = 1;
+    cpu_features->has_neon_aes = 1;
 #elif defined(_M_ARM64)
-    cpu_features->has_armcrypto =
+    cpu_features->has_neon_aes =
         1; /* assuming all CPUs supported by ARM Windows have the crypto extensions */
 #elif defined(__APPLE__) && defined(CPU_TYPE_ARM64) && defined(CPU_SUBTYPE_ARM64E)
     {
@@ -103,30 +103,30 @@ _runtime_arm_cpu_features(CPUFeatures *const cpu_features)
             cpu_type == CPU_TYPE_ARM64 &&
             sysctlbyname("hw.cpusubtype", &cpu_subtype, &cpu_subtype_len, NULL, 0) == 0 &&
             (cpu_subtype == CPU_SUBTYPE_ARM64E || cpu_subtype == CPU_SUBTYPE_ARM64_V8)) {
-            cpu_features->has_armcrypto = 1;
+            cpu_features->has_neon_aes = 1;
         }
     }
 #elif defined(HAVE_ANDROID_GETCPUFEATURES) && defined(ANDROID_CPU_ARM_FEATURE_AES)
-    cpu_features->has_armcrypto = (android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_AES) != 0x0;
+    cpu_features->has_neon_aes = (android_getCpuFeatures() & ANDROID_CPU_ARM_FEATURE_AES) != 0x0;
 #elif (defined(__aarch64__) || defined(_M_ARM64)) && defined(AT_HWCAP)
 #    ifdef HAVE_GETAUXVAL
-    cpu_features->has_armcrypto = (getauxval(AT_HWCAP) & (1L << 3)) != 0;
+    cpu_features->has_neon_aes = (getauxval(AT_HWCAP) & (1L << 3)) != 0;
 #    elif defined(HAVE_ELF_AUX_INFO)
     {
         unsigned long buf;
         if (elf_aux_info(AT_HWCAP, (void *) &buf, (int) sizeof buf) == 0) {
-            cpu_features->has_armcrypto = (buf & (1L << 3)) != 0;
+            cpu_features->has_neon_aes = (buf & (1L << 3)) != 0;
         }
     }
 #    endif
 #elif defined(__arm__) && defined(AT_HWCAP2)
 #    ifdef HAVE_GETAUXVAL
-    cpu_features->has_armcrypto = (getauxval(AT_HWCAP2) & (1L << 0)) != 0;
+    cpu_features->has_neon_aes = (getauxval(AT_HWCAP2) & (1L << 0)) != 0;
 #    elif defined(HAVE_ELF_AUX_INFO)
     {
         unsigned long buf;
         if (elf_aux_info(AT_HWCAP2, (void *) &buf, (int) sizeof buf) == 0) {
-            cpu_features->has_armcrypto = (buf & (1L << 0)) != 0;
+            cpu_features->has_neon_aes = (buf & (1L << 0)) != 0;
         }
     }
 #    endif
@@ -293,9 +293,9 @@ aegis_runtime_has_neon(void)
 }
 
 int
-aegis_runtime_has_armcrypto(void)
+aegis_runtime_has_neon_aes(void)
 {
-    return _cpu_features.has_armcrypto;
+    return _cpu_features.has_neon_aes;
 }
 
 int

--- a/src/common/cpu.h
+++ b/src/common/cpu.h
@@ -13,7 +13,7 @@ int aegis_runtime_get_cpu_features(void);
 
 int aegis_runtime_has_neon(void);
 
-int aegis_runtime_has_armcrypto(void);
+int aegis_runtime_has_neon_aes(void);
 
 int aegis_runtime_has_avx(void);
 


### PR DESCRIPTION
The Arm 64-bit architecture contains a number of architecture extensions relevant to the AEGIS family of algorithms, however currently libaegis only checks and exposes `FEAT_AES`. In particular:

* `FEAT_SHA3` contains the Neon `EOR3` and `BCAX` instructions which can be useful for e.g. combining pairs of exclusive-or instructions.

* `FEAT_SVE_AES` provides SVE versions of the existing `AESE` and `AESMC` instructions. These can be beneficial on micro-architectures with longer vectors.

* `FEAT_SVE2` provides SVE2 versions of the `EOR3` and `BCAX` instructions, mirroring the Neon versions but for SVE vectors.

As a first step towards supporting these new extensions, rename the existing code to disambiguate away from "armcrypto" and instead refer to the exact "neon_aes" extension that the code depends on.