### PR TITLE
Add feature detection for AArch64 FEAT_SHA3 and FEAT_SVE_AES

### DIFF
--- a/src/common/cpu.h
+++ b/src/common/cpu.h
@@ -17,6 +17,8 @@ int aegis_runtime_has_neon_aes(void);
 
 int aegis_runtime_has_neon_sha3(void);
 
+int aegis_runtime_has_sve2_aes(void);
+
 int aegis_runtime_has_avx(void);
 
 int aegis_runtime_has_avx2(void);

--- a/src/common/cpu.h
+++ b/src/common/cpu.h
@@ -15,6 +15,8 @@ int aegis_runtime_has_neon(void);
 
 int aegis_runtime_has_neon_aes(void);
 
+int aegis_runtime_has_neon_sha3(void);
+
 int aegis_runtime_has_avx(void);
 
 int aegis_runtime_has_avx2(void);


### PR DESCRIPTION
The `FEAT_SHA3` extension provides support for the `BCAX` ("bit-clear and xor") and `EOR3` ("exclusive-or, 3-input") instructions. 

The `FEAT_SVE2` extension provides support for Arm Scalable Vector Extension (SVE) variants of the `EOR3` and `BCAX` instructions. `FEAT_SVE_AES` is a further optional extension introduced as part of the Arm v9.0-A architecture that provides support for SVE variants of the existing Neon `AESE` and `AESMC` instructions. If `FEAT_SVE_AES` is present then `FEAT_SVE2` must also be present (and there is no point in attempting to write an implementation without `FEAT_SVE_AES`), so it is sufficient to only check for the presence of `FEAT_SVE_AES`.

This PR adds support for feature detection on Windows, Apple Silicon, and `getauxval`-based platforms (Linux and Android). There is no ability to detect `FEAT_SHA3` on Windows, however since `FEAT_SVE_AES` also implies that
`FEAT_SHA3` is present, just try and detect `FEAT_SVE_AES` instead.

Additionally clean up the existing code to reduce duplication of `getauxval` and `sysctlbyname` function calls.