### PR TITLE
Add AArch64 FEAT_SHA3 implementation of AEGIS128L

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -32,6 +32,7 @@ pub fn build(b: *std.Build) void {
         "src/aegis128l/aegis128l_aesni.c",
         "src/aegis128l/aegis128l_altivec.c",
         "src/aegis128l/aegis128l_neon_aes.c",
+        "src/aegis128l/aegis128l_neon_sha3.c",
         "src/aegis128l/aegis128l_soft.c",
         "src/aegis128l/aegis128l.c",
 
@@ -46,7 +47,6 @@ pub fn build(b: *std.Build) void {
         "src/aegis128x4/aegis128x4_altivec.c",
         "src/aegis128x4/aegis128x4_avx2.c",
         "src/aegis128x4/aegis128x4_avx512.c",
-        "src/aegis128x4/aegis128x4_neon_aes.c",
         "src/aegis128x4/aegis128x4_neon_aes.c",
         "src/aegis128x4/aegis128x4_soft.c",
         "src/aegis128x4/aegis128x4.c",

--- a/src/aegis128l/aegis128l.c
+++ b/src/aegis128l/aegis128l.c
@@ -7,6 +7,7 @@
 #include "aegis128l_aesni.h"
 #include "aegis128l_altivec.h"
 #include "aegis128l_neon_aes.h"
+#include "aegis128l_neon_sha3.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis128l_soft.h"
@@ -232,6 +233,10 @@ aegis128l_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
+    if (aegis_runtime_has_neon_sha3()) {
+        implementation = &aegis128l_neon_sha3_implementation;
+        return 0;
+    }
     if (aegis_runtime_has_neon_aes()) {
         implementation = &aegis128l_neon_aes_implementation;
         return 0;

--- a/src/aegis128l/aegis128l_neon_sha3.c
+++ b/src/aegis128l/aegis128l_neon_sha3.c
@@ -1,0 +1,83 @@
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#    include <stddef.h>
+#    include <stdint.h>
+
+#    include "../common/common.h"
+#    include "aegis128l.h"
+#    include "aegis128l_neon_sha3.h"
+
+#    ifndef __ARM_FEATURE_CRYPTO
+#        define __ARM_FEATURE_CRYPTO 1
+#    endif
+#    ifndef __ARM_FEATURE_AES
+#        define __ARM_FEATURE_AES 1
+#    endif
+#    ifndef __ARM_FEATURE_SHA3
+#        define __ARM_FEATURE_SHA3 1
+#    endif
+
+#    include <arm_neon.h>
+
+#    ifdef __clang__
+#        pragma clang attribute push(__attribute__((target("neon,crypto,aes,sha3"))), \
+                                     apply_to = function)
+#    elif defined(__GNUC__)
+#        pragma GCC target("+simd+crypto+sha3")
+#    endif
+
+#    define AES_BLOCK_LENGTH 16
+
+typedef uint8x16_t aes_block_t;
+
+#    define AES_BLOCK_XOR(A, B)       veorq_u8((A), (B))
+#    define AES_BLOCK_XOR3(A, B, C)   veor3q_u8((A), (B), (C))
+#    define AES_BLOCK_AND(A, B)       vandq_u8((A), (B))
+#    define AES_BLOCK_LOAD(A)         vld1q_u8(A)
+#    define AES_BLOCK_LOAD_64x2(A, B) vreinterpretq_u8_u64(vsetq_lane_u64((A), vmovq_n_u64(B), 1))
+#    define AES_BLOCK_STORE(A, B)     vst1q_u8((A), (B))
+#    define AES_ENC0(A)               vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), (A)))
+#    define AES_ENC(A, B)             AES_BLOCK_XOR(AES_ENC0(A), (B))
+
+static inline void
+aegis128l_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
+{
+    aes_block_t tmp;
+
+    tmp      = state[7];
+    state[7] = AES_ENC(state[6], state[7]);
+    state[6] = AES_ENC(state[5], state[6]);
+    state[5] = AES_ENC(state[4], state[5]);
+    state[4] = AES_BLOCK_XOR3(state[4], AES_ENC0(state[3]), d2);
+    state[3] = AES_ENC(state[2], state[3]);
+    state[2] = AES_ENC(state[1], state[2]);
+    state[1] = AES_ENC(state[0], state[1]);
+    state[0] = AES_BLOCK_XOR3(state[0], AES_ENC0(tmp), d1);
+}
+
+#    include "aegis128l_common.h"
+
+struct aegis128l_implementation aegis128l_neon_sha3_implementation = {
+    .encrypt_detached              = encrypt_detached,
+    .decrypt_detached              = decrypt_detached,
+    .encrypt_unauthenticated       = encrypt_unauthenticated,
+    .decrypt_unauthenticated       = decrypt_unauthenticated,
+    .stream                        = stream,
+    .state_init                    = state_init,
+    .state_encrypt_update          = state_encrypt_update,
+    .state_encrypt_detached_final  = state_encrypt_detached_final,
+    .state_encrypt_final           = state_encrypt_final,
+    .state_decrypt_detached_update = state_decrypt_detached_update,
+    .state_decrypt_detached_final  = state_decrypt_detached_final,
+    .state_mac_init                = state_mac_init,
+    .state_mac_update              = state_mac_update,
+    .state_mac_final               = state_mac_final,
+    .state_mac_reset               = state_mac_reset,
+    .state_mac_clone               = state_mac_clone,
+};
+
+#    ifdef __clang__
+#        pragma clang attribute pop
+#    endif
+
+#endif

--- a/src/aegis128l/aegis128l_neon_sha3.h
+++ b/src/aegis128l/aegis128l_neon_sha3.h
@@ -1,0 +1,9 @@
+#ifndef aegis128l_neon_sha3_H
+#define aegis128l_neon_sha3_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis128l_implementation aegis128l_neon_sha3_implementation;
+
+#endif


### PR DESCRIPTION
Add an implementation of AEGIS128L using the Neon `FEAT_SHA3` extension. This allows use of the `EOR3` and `BCAX` instructions.

Running the benchmarks on Arm Neoverse micro-architectures with LLVM 20, this gives the following changes (higher is better, 100% = no change):

                    Neoverse V1     Neoverse V2     Neoverse N2
    AEGIS-128L      112.62%         114.91%         116.28%
    AEGIS-128L MAC  81.10%          80.32%          93.89%

The `EOR3` instruction as present in the above cores has worse throughput than the standard `EOR` instruction, with only one `EOR3` instruction being issued per cycle. This is compared to four `EOR` instructions per cycle on Neoverse V1 and Neoverse V2, and two per cycle on Neoverse N2.

This difference in performance observation can therefore be explained as such:

* For AEGIS-128L, the presence of a small number of `EOR3` instructions reduces the overall vector instruction count and therefore improves performance. The reduced throughput of `EOR3` instructions is not an issue here since the limiting factor is the number of other instructions executing on the remaining vector units.

* For AEGIS-128L MAC, there are more `EOR3` instructions automatically emitted by the compiler combining `EOR` intrinsics, leading to the limited throughput of these instructions becoming more of an issue and an overall slowdown in performance.

The imbalance between `EOR` and `EOR3` instruction throughputs is resolved from Neoverse V3 and Neoverse N3, so it is expected that the MAC performance inversion is limited to this current generation of micro-architectures.

For comparison, when running on client cores which do not have the `EOR3` throughput limitation, we instead observe the following improvements:

                    Cortex-A520     Cortex-A720     Cortex-X4
    AEGIS-128L      121.57%         117.18%         116.32%
    AEGIS-128L MAC  118.90%         112.52%         112.01%