### PR TITLE
benchmark: Use new writer interface to access stdout

### DIFF
--- a/src/test/benchmark.zig
+++ b/src/test/benchmark.zig
@@ -8,6 +8,10 @@ const Timer = std.time.Timer;
 const msg_len: usize = 16384;
 const iterations = 100000;
 
+pub fn get_stdout() std.fs.File.Writer {
+    return std.io.getStdOut().writer();
+}
+
 fn bench_aegis256() !void {
     var key: [aegis.aegis256_KEYBYTES]u8 = undefined;
     var nonce: [aegis.aegis256_NPUBBYTES]u8 = undefined;
@@ -36,8 +40,7 @@ fn bench_aegis256() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-256\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-256\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis256x2() !void {
@@ -68,8 +71,7 @@ fn bench_aegis256x2() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-256X2\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-256X2\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis256x4() !void {
@@ -100,8 +102,7 @@ fn bench_aegis256x4() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-256X4\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-256X4\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis128l() !void {
@@ -132,8 +133,7 @@ fn bench_aegis128l() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-128L\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-128L\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis128x2() !void {
@@ -164,8 +164,7 @@ fn bench_aegis128x2() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-128X2\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-128X2\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis128x4() !void {
@@ -196,8 +195,7 @@ fn bench_aegis128x4() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-128X4\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-128X4\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis128l_mac() !void {
@@ -223,8 +221,7 @@ fn bench_aegis128l_mac() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-128L MAC\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-128L MAC\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis128x2_mac() !void {
@@ -250,8 +247,7 @@ fn bench_aegis128x2_mac() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-128X2 MAC\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-128X2 MAC\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis128x4_mac() !void {
@@ -278,8 +274,7 @@ fn bench_aegis128x4_mac() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-128X4 MAC\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-128X4 MAC\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis256_mac() !void {
@@ -305,8 +300,7 @@ fn bench_aegis256_mac() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-256 MAC\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-256 MAC\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis256x2_mac() !void {
@@ -333,8 +327,7 @@ fn bench_aegis256x2_mac() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-256X2 MAC\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-256X2 MAC\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 fn bench_aegis256x4_mac() !void {
@@ -361,8 +354,7 @@ fn bench_aegis256x4_mac() !void {
     const bits: f128 = @floatFromInt(@as(u128, msg_len) * iterations * 8);
     const elapsed_s = @as(f128, @floatFromInt(end - start)) / time.ns_per_s;
     const throughput = @as(f64, @floatCast(bits / (elapsed_s * 1000 * 1000)));
-    const stdout = std.fs.File.stdout().deprecatedWriter();
-    try stdout.print("AEGIS-256X4 MAC\t{d:10.2} Mb/s\n", .{throughput});
+    try get_stdout().print("AEGIS-256X4 MAC\t{d:10.2} Mb/s\n", .{throughput});
 }
 
 pub fn main() !void {


### PR DESCRIPTION
It seems like `std.fs.File.stdout()` no longer exists with recent versions of Zig, so use the new `std.io.getStdOut().writer()` instead.