### PR TITLE
Fix output buffer length calculation in `state_decrypt_detached_update`

### DIFF
--- a/src/aegis128l/aegis128l_common.h
+++ b/src/aegis128l/aegis128l_common.h
@@ -510,7 +510,7 @@ state_decrypt_detached_update(aegis128l_state *st_, uint8_t *m, size_t mlen_max,
         *written += RATE;
     }
     if (m != NULL) {
-        if (mlen_max < (clen % RATE)) {
+        if (mlen_max < (clen & ~(size_t) (RATE - 1))) {
             errno = ERANGE;
             return -1;
         }

--- a/src/aegis128x2/aegis128x2_common.h
+++ b/src/aegis128x2/aegis128x2_common.h
@@ -615,7 +615,7 @@ state_decrypt_detached_update(aegis128x2_state *st_, uint8_t *m, size_t mlen_max
     }
 
     if (m != NULL) {
-        if (mlen_max < (clen % RATE)) {
+        if (mlen_max < (clen & ~(size_t) (RATE - 1))) {
             errno = ERANGE;
             return -1;
         }

--- a/src/aegis128x4/aegis128x4_common.h
+++ b/src/aegis128x4/aegis128x4_common.h
@@ -630,7 +630,7 @@ state_decrypt_detached_update(aegis128x4_state *st_, uint8_t *m, size_t mlen_max
     }
 
     if (m != NULL) {
-        if (mlen_max < (clen % RATE)) {
+        if (mlen_max < (clen & ~(size_t) (RATE - 1))) {
             errno = ERANGE;
             return -1;
         }

--- a/src/aegis256/aegis256_common.h
+++ b/src/aegis256/aegis256_common.h
@@ -498,7 +498,7 @@ state_decrypt_detached_update(aegis256_state *st_, uint8_t *m, size_t mlen_max, 
     }
 
     if (m != NULL) {
-        if (mlen_max < (clen % RATE)) {
+        if (mlen_max < (clen & ~(size_t) (RATE - 1))) {
             errno = ERANGE;
             return -1;
         }

--- a/src/aegis256x2/aegis256x2_common.h
+++ b/src/aegis256x2/aegis256x2_common.h
@@ -613,7 +613,7 @@ state_decrypt_detached_update(aegis256x2_state *st_, uint8_t *m, size_t mlen_max
     }
 
     if (m != NULL) {
-        if (mlen_max < (clen % RATE)) {
+        if (mlen_max < (clen & ~(size_t) (RATE - 1))) {
             errno = ERANGE;
             return -1;
         }

--- a/src/aegis256x4/aegis256x4_common.h
+++ b/src/aegis256x4/aegis256x4_common.h
@@ -632,7 +632,7 @@ state_decrypt_detached_update(aegis256x4_state *st_, uint8_t *m, size_t mlen_max
     }
 
     if (m != NULL) {
-        if (mlen_max < (clen % RATE)) {
+        if (mlen_max < (clen & ~(size_t) (RATE - 1))) {
             errno = ERANGE;
             return -1;
         }


### PR DESCRIPTION
The function produces only blocks of RATE bytes. Correctly check against that limit.

The old code was requiring 0..RATE-1 rather than n * RATE of the output buffer size. This caused it to SEGFAULT with sufficiently large inputs given an output buffer too small, and also caused it to require more space than actually written (=0) for inputs shorter than RATE.

With the patch, the function requires the output buffer to hold the number of bytes that it actually writes, and correctly returns ERANGE error for anything less.

Note: the encrypt update function already used this condition that I used in the patch on decrypt.

