### PR TITLE
Arm: Conditionally negate state[{3,7}] to enable using SHA3 BCAX

### DIFF
--- a/src/aegis128l/aegis128l_common.h
+++ b/src/aegis128l/aegis128l_common.h
@@ -1,6 +1,13 @@
 #define RATE      32
 #define ALIGNMENT 32
 
+// If not inverting state[3] and state[7], treat bitwise-NOT operations as
+// no-ops.
+#ifndef AES_INVERT_STATE37
+#    define AES_BLOCK_NOT(A) (A)
+#    define AES_BLOCK_XNOR(A, B) AES_BLOCK_XOR((A), (B))
+#endif
+
 typedef aes_block_t aegis_blocks[8];
 
 static void
@@ -25,11 +32,11 @@ aegis128l_init(const uint8_t *key, const uint8_t *nonce, aes_block_t *const stat
     state[0] = AES_BLOCK_XOR(k, n);
     state[1] = c1;
     state[2] = c0;
-    state[3] = c1;
+    state[3] = AES_BLOCK_NOT(c1);
     state[4] = AES_BLOCK_XOR(k, n);
     state[5] = AES_BLOCK_XOR(k, c0);
     state[6] = AES_BLOCK_XOR(k, c1);
-    state[7] = AES_BLOCK_XOR(k, c0);
+    state[7] = AES_BLOCK_XNOR(k, c0);
     for (i = 0; i < 10; i++) {
         aegis128l_update(state, n, k);
     }
@@ -50,14 +57,14 @@ aegis128l_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_bl
 
     if (maclen == 16) {
         tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac, tmp);
     } else if (maclen == 32) {
-        tmp = AES_BLOCK_XOR(state[3], state[2]);
+        tmp = AES_BLOCK_XNOR(state[3], state[2]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac, tmp);
-        tmp = AES_BLOCK_XOR(state[7], state[6]);
+        tmp = AES_BLOCK_XNOR(state[7], state[6]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[5], state[4]));
         AES_BLOCK_STORE(mac + 16, tmp);
     } else {
@@ -91,9 +98,9 @@ aegis128l_squeeze_keystream(uint8_t *const dst, aes_block_t *const state)
     aes_block_t tmp0, tmp1;
 
     tmp0 = AES_BLOCK_XOR(state[6], state[1]);
-    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], state[3]));
+    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     tmp1 = AES_BLOCK_XOR(state[5], state[2]);
-    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], state[7]));
+    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, tmp0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, tmp1);
 }
@@ -110,8 +117,8 @@ aegis128l_enc(uint8_t *const dst, const uint8_t *const src, aes_block_t *const s
     tmp0 = AES_BLOCK_XOR(tmp0, state[1]);
     tmp1 = AES_BLOCK_XOR(msg1, state[5]);
     tmp1 = AES_BLOCK_XOR(tmp1, state[2]);
-    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], state[3]));
-    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], state[7]));
+    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, tmp0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, tmp1);
 
@@ -129,8 +136,8 @@ aegis128l_dec(uint8_t *const dst, const uint8_t *const src, aes_block_t *const s
     msg0 = AES_BLOCK_XOR(msg0, state[1]);
     msg1 = AES_BLOCK_XOR(msg1, state[5]);
     msg1 = AES_BLOCK_XOR(msg1, state[2]);
-    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], state[3]));
-    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], state[7]));
+    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, msg0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, msg1);
 
@@ -153,8 +160,8 @@ aegis128l_declast(uint8_t *const dst, const uint8_t *const src, size_t len,
     msg0 = AES_BLOCK_XOR(msg0, state[1]);
     msg1 = AES_BLOCK_XOR(msg1, state[5]);
     msg1 = AES_BLOCK_XOR(msg1, state[2]);
-    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], state[3]));
-    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], state[7]));
+    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(pad, msg0);
     AES_BLOCK_STORE(pad + AES_BLOCK_LENGTH, msg1);
 

--- a/src/aegis128l/aegis128l_neon_sha3.c
+++ b/src/aegis128l/aegis128l_neon_sha3.c
@@ -31,32 +31,64 @@
 #    endif
 
 #    define AES_BLOCK_LENGTH 16
+#    define AES_INVERT_STATE37 1
 
 typedef uint8x16_t aes_block_t;
 
+static const uint8_t ones_arr[] = { 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU };
+
+static inline uint8x16_t fresh_ones() {
+  // The AESE instruction first operand register is both an input and output to
+  // the instruction. If the first operand is used in multiple places, this can
+  // therefore force compilers to emit MOV instructions to duplicate the value.
+  // In AES_ENC0 we use a zero register which would ordinarily have this
+  // problem since the compiler can merge the zero constants together and reuse
+  // them, however compilers typically treat this as a special case since
+  // materializing zero is a zero-cost instruction on many micro-architectures.
+  // For AES_ENC1 we cannot use this trick: materialising 0xFF is not usually
+  // zero-cost so compilers do not treat it specially, however since this
+  // region of the code is so heavy in vector arithmetic, inserting an
+  // additional load instruction here is effectively free.
+  uint8x16_t ret;
+  __asm volatile("ldr %q0, %1": "=w"(ret): "m"(ones_arr));
+  return ret;
+}
+
+#    define AES_BLOCK_NOT(A)          vmvnq_u8((A))
 #    define AES_BLOCK_XOR(A, B)       veorq_u8((A), (B))
+#    define AES_BLOCK_XNOR(A, B)      veor3q_u8((A), (B), vmovq_n_u8(0xFF))
 #    define AES_BLOCK_XOR3(A, B, C)   veor3q_u8((A), (B), (C))
 #    define AES_BLOCK_AND(A, B)       vandq_u8((A), (B))
 #    define AES_BLOCK_LOAD(A)         vld1q_u8(A)
 #    define AES_BLOCK_LOAD_64x2(A, B) vreinterpretq_u8_u64(vsetq_lane_u64((A), vmovq_n_u64(B), 1))
 #    define AES_BLOCK_STORE(A, B)     vst1q_u8((A), (B))
 #    define AES_ENC0(A)               vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), (A)))
+#    define AES_ENC1(A)               vaesmcq_u8(vaeseq_u8(fresh_ones(), (A)))
 #    define AES_ENC(A, B)             AES_BLOCK_XOR(AES_ENC0(A), (B))
 
 static inline void
 aegis128l_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
 {
-    aes_block_t tmp;
+    // Apply bitwise-NOT to state[3] and state[7] to allow us to use the Arm
+    // SHA3 BCAX instruction.
+    aes_block_t enc7 = AES_ENC1(state[7]);
+    aes_block_t enc6 = AES_ENC0(state[6]);
+    aes_block_t enc5 = AES_ENC0(state[5]);
+    aes_block_t enc4 = AES_ENC0(state[4]);
+    aes_block_t enc3 = AES_ENC1(state[3]);
+    aes_block_t enc2 = AES_ENC0(state[2]);
+    aes_block_t enc1 = AES_ENC0(state[1]);
+    aes_block_t enc0 = AES_ENC0(state[0]);
 
-    tmp      = state[7];
-    state[7] = AES_ENC(state[6], state[7]);
-    state[6] = AES_ENC(state[5], state[6]);
-    state[5] = AES_ENC(state[4], state[5]);
-    state[4] = AES_BLOCK_XOR3(state[4], AES_ENC0(state[3]), d2);
-    state[3] = AES_ENC(state[2], state[3]);
-    state[2] = AES_ENC(state[1], state[2]);
-    state[1] = AES_ENC(state[0], state[1]);
-    state[0] = AES_BLOCK_XOR3(state[0], AES_ENC0(tmp), d1);
+    state[7] = AES_BLOCK_XOR(enc6, state[7]);
+    state[6] = AES_BLOCK_XOR(enc5, state[6]);
+    state[5] = AES_BLOCK_XOR(enc4, state[5]);
+    state[4] = AES_BLOCK_XOR3(enc3, state[4], d2);
+    state[3] = AES_BLOCK_XOR(enc2, state[3]);
+    state[2] = AES_BLOCK_XOR(enc1, state[2]);
+    state[1] = AES_BLOCK_XOR(enc0, state[1]);
+    state[0] = AES_BLOCK_XOR3(enc7, state[0], d1);
 }
 
 #    include "aegis128l_common.h"


### PR DESCRIPTION
The `aegis128l_common.h` code contains repeated lines of paired XOR and AND operations, for example:

    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], state[3]));

This is suboptimal on Arm because there is no instruction do to XOR and AND in a single instruction.

The `FEAT_SHA3` extension includes the `BCAX` (bit-clear and XOR) instruction which is the equivalent of `XOR(a, AND(b, NOT(c)))`, however this does not quite match due to the need to negate `c`.

To enable the `BCAX` instruction to be used, introduce a new `AES_INVERT_STATE37` toggle to optionally store `state[3]` and `state[7]` as bitwise-negated in `aegis128l_common.h`. With LLVM 22 this is sufficient to have the compiler automatically make use of the BCAX instructions so there is no need to use them explicitly.

Since `state[3]` and `state[7]` are now bitwise-negated, also update `aegis128l_neon_sha3.c` to add a new `AES_ENC1` macro that undoes the bitwise negation as part of the AESE instruction. The compiler will ordinarily try to materialise the all-ones constant here in a sub-optimal way, necessitating the use of inline assembly.

Benchmarking this on a range of Arm Neoverse platforms with LLVM 22, we see a 5-15% speedup over the existing Neon SHA3 implementation.