### PR TITLE
Fix compilation with clang 22

### DIFF
--- a/src/aegis128x4/aegis128x4_avx512.c
+++ b/src/aegis128x4/aegis128x4_avx512.c
@@ -10,13 +10,8 @@
 #    ifdef HAVE_VAESINTRIN_H
 
 #        ifdef __clang__
-#            if __clang_major__ >= 18
-#                pragma clang attribute push(__attribute__((target("aes,vaes,avx512f,evex512"))), \
-                                             apply_to = function)
-#            else
-#                pragma clang attribute push(__attribute__((target("aes,vaes,avx512f"))), \
-                                             apply_to = function)
-#            endif
+#            pragma clang attribute push(__attribute__((target("aes,vaes,avx512f"))), \
+                                         apply_to = function)
 #        elif defined(__GNUC__)
 #            pragma GCC target("aes,vaes,avx512f")
 #        endif

--- a/src/aegis256x4/aegis256x4_avx512.c
+++ b/src/aegis256x4/aegis256x4_avx512.c
@@ -10,13 +10,8 @@
 #    ifdef HAVE_VAESINTRIN_H
 
 #        ifdef __clang__
-#            if __clang_major__ >= 18
-#                pragma clang attribute push(__attribute__((target("aes,vaes,avx512f,evex512"))), \
-                                             apply_to = function)
-#            else
-#                pragma clang attribute push(__attribute__((target("aes,vaes,avx512f"))), \
-                                             apply_to = function)
-#            endif
+#            pragma clang attribute push(__attribute__((target("aes,vaes,avx512f"))), \
+                                         apply_to = function)
 #        elif defined(__GNUC__)
 #            pragma GCC target("aes,vaes,avx512f")
 #        endif


### PR DESCRIPTION
The libaegis code specified a target option "evex512" for clang version 18 and higher. While clang 18 ignored the unknown option, clang 22 (and most likely other versions between 18 and 22) complained about the unknown option and ignores ALL target options. This leads to hard compile errors later on.

The solution is to simply drop the invalid target option.