### PR TITLE
Arm: Introduce Neon SHA3 versions for AEGIS non-128L functions

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -43,6 +43,7 @@ pub fn build(b: *std.Build) void {
         "src/aegis128x2/aegis128x2_altivec.c",
         "src/aegis128x2/aegis128x2_avx2.c",
         "src/aegis128x2/aegis128x2_neon_aes.c",
+        "src/aegis128x2/aegis128x2_neon_sha3.c",
         "src/aegis128x2/aegis128x2_soft.c",
         "src/aegis128x2/aegis128x2.c",
 
@@ -51,12 +52,14 @@ pub fn build(b: *std.Build) void {
         "src/aegis128x4/aegis128x4_avx2.c",
         "src/aegis128x4/aegis128x4_avx512.c",
         "src/aegis128x4/aegis128x4_neon_aes.c",
+        "src/aegis128x4/aegis128x4_neon_sha3.c",
         "src/aegis128x4/aegis128x4_soft.c",
         "src/aegis128x4/aegis128x4.c",
 
         "src/aegis256/aegis256_aesni.c",
         "src/aegis256/aegis256_altivec.c",
         "src/aegis256/aegis256_neon_aes.c",
+        "src/aegis256/aegis256_neon_sha3.c",
         "src/aegis256/aegis256_soft.c",
         "src/aegis256/aegis256.c",
 
@@ -64,6 +67,7 @@ pub fn build(b: *std.Build) void {
         "src/aegis256x2/aegis256x2_altivec.c",
         "src/aegis256x2/aegis256x2_avx2.c",
         "src/aegis256x2/aegis256x2_neon_aes.c",
+        "src/aegis256x2/aegis256x2_neon_sha3.c",
         "src/aegis256x2/aegis256x2_soft.c",
         "src/aegis256x2/aegis256x2.c",
 
@@ -72,6 +76,7 @@ pub fn build(b: *std.Build) void {
         "src/aegis256x4/aegis256x4_avx2.c",
         "src/aegis256x4/aegis256x4_avx512.c",
         "src/aegis256x4/aegis256x4_neon_aes.c",
+        "src/aegis256x4/aegis256x4_neon_sha3.c",
         "src/aegis256x4/aegis256x4_soft.c",
         "src/aegis256x4/aegis256x4.c",
 

--- a/src/aegis128x2/aegis128x2.c
+++ b/src/aegis128x2/aegis128x2.c
@@ -8,6 +8,7 @@
 #include "aegis128x2_altivec.h"
 #include "aegis128x2_avx2.h"
 #include "aegis128x2_neon_aes.h"
+#include "aegis128x2_neon_sha3.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis128x2_soft.h"
@@ -217,6 +218,10 @@ aegis128x2_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
+    if (aegis_runtime_has_neon_sha3()) {
+        implementation = &aegis128x2_neon_sha3_implementation;
+        return 0;
+    }
     if (aegis_runtime_has_neon_aes()) {
         implementation = &aegis128x2_neon_aes_implementation;
         return 0;

--- a/src/aegis128x2/aegis128x2_common.h
+++ b/src/aegis128x2/aegis128x2_common.h
@@ -1,6 +1,13 @@
 #define RATE      64
 #define ALIGNMENT 64
 
+// If not inverting state[3] and state[7], treat bitwise-NOT operations as
+// no-ops.
+#ifndef AES_INVERT_STATE37
+#    define AES_BLOCK_NOT(A) (A)
+#    define AES_BLOCK_XNOR(A, B) AES_BLOCK_XOR((A), (B))
+#endif
+
 typedef aes_block_t aegis_blocks[8];
 
 static inline void
@@ -44,11 +51,11 @@ aegis128x2_init(const uint8_t *key, const uint8_t *nonce, aes_block_t *const sta
     state[0] = AES_BLOCK_XOR(k, n);
     state[1] = c1;
     state[2] = c0;
-    state[3] = c1;
+    state[3] = AES_BLOCK_NOT(c1);
     state[4] = AES_BLOCK_XOR(k, n);
     state[5] = AES_BLOCK_XOR(k, c0);
     state[6] = AES_BLOCK_XOR(k, c1);
-    state[7] = AES_BLOCK_XOR(k, c0);
+    state[7] = AES_BLOCK_XNOR(k, c0);
     for (i = 0; i < 10; i++) {
         state[3] = AES_BLOCK_XOR(state[3], context);
         state[7] = AES_BLOCK_XOR(state[7], context);
@@ -73,21 +80,21 @@ aegis128x2_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
 
     if (maclen == 16) {
         tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac_multi_0, tmp);
         for (i = 0; i < 16; i++) {
             mac[i] = mac_multi_0[i] ^ mac_multi_0[1 * 16 + i];
         }
     } else if (maclen == 32) {
-        tmp = AES_BLOCK_XOR(state[3], state[2]);
+        tmp = AES_BLOCK_XNOR(state[3], state[2]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac_multi_0, tmp);
         for (i = 0; i < 16; i++) {
             mac[i] = mac_multi_0[i] ^ mac_multi_0[1 * 16 + i];
         }
 
-        tmp = AES_BLOCK_XOR(state[7], state[6]);
+        tmp = AES_BLOCK_XNOR(state[7], state[6]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[5], state[4]));
         AES_BLOCK_STORE(mac_multi_1, tmp);
         for (i = 0; i < 16; i++) {
@@ -124,9 +131,9 @@ aegis128x2_squeeze_keystream(uint8_t *const dst, aes_block_t *const state)
     aes_block_t tmp0, tmp1;
 
     tmp0 = AES_BLOCK_XOR(state[6], state[1]);
-    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], state[3]));
+    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     tmp1 = AES_BLOCK_XOR(state[5], state[2]);
-    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], state[7]));
+    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, tmp0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, tmp1);
 }
@@ -143,8 +150,8 @@ aegis128x2_enc(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     tmp0 = AES_BLOCK_XOR(tmp0, state[1]);
     tmp1 = AES_BLOCK_XOR(msg1, state[5]);
     tmp1 = AES_BLOCK_XOR(tmp1, state[2]);
-    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], state[3]));
-    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], state[7]));
+    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, tmp0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, tmp1);
 
@@ -162,8 +169,8 @@ aegis128x2_dec(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     msg0 = AES_BLOCK_XOR(msg0, state[1]);
     msg1 = AES_BLOCK_XOR(msg1, state[5]);
     msg1 = AES_BLOCK_XOR(msg1, state[2]);
-    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], state[3]));
-    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], state[7]));
+    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, msg0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, msg1);
 
@@ -186,8 +193,8 @@ aegis128x2_declast(uint8_t *const dst, const uint8_t *const src, size_t len,
     msg0 = AES_BLOCK_XOR(msg0, state[1]);
     msg1 = AES_BLOCK_XOR(msg1, state[5]);
     msg1 = AES_BLOCK_XOR(msg1, state[2]);
-    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], state[3]));
-    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], state[7]));
+    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(pad, msg0);
     AES_BLOCK_STORE(pad + AES_BLOCK_LENGTH, msg1);
 
@@ -220,7 +227,7 @@ aegis128x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
     if (maclen == 16) {
 #if AES_BLOCK_LENGTH > 16
         tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         for (i = 0; i < d / 2; i++) {
@@ -235,16 +242,16 @@ aegis128x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
         }
 #endif
         tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
     } else if (maclen == 32) {
 #if AES_BLOCK_LENGTH > 16
-        tmp = AES_BLOCK_XOR(state[3], state[2]);
+        tmp = AES_BLOCK_XNOR(state[3], state[2]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
-        tmp = AES_BLOCK_XOR(state[7], state[6]);
+        tmp = AES_BLOCK_XNOR(state[7], state[6]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[5], state[4]));
         AES_BLOCK_STORE(t + AES_BLOCK_LENGTH, tmp);
         for (i = 1; i < d; i++) {
@@ -258,11 +265,11 @@ aegis128x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
             aegis128x2_update(state, tmp, tmp);
         }
 #endif
-        tmp = AES_BLOCK_XOR(state[3], state[2]);
+        tmp = AES_BLOCK_XNOR(state[3], state[2]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
-        tmp = AES_BLOCK_XOR(state[7], state[6]);
+        tmp = AES_BLOCK_XNOR(state[7], state[6]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[5], state[4]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac + 16, t, 16);

--- a/src/aegis128x2/aegis128x2_neon_sha3.c
+++ b/src/aegis128x2/aegis128x2_neon_sha3.c
@@ -1,0 +1,181 @@
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#    include <stddef.h>
+#    include <stdint.h>
+
+#    include "../common/common.h"
+#    include "aegis128x2.h"
+#    include "aegis128x2_neon_sha3.h"
+
+#    ifndef __ARM_FEATURE_CRYPTO
+#        define __ARM_FEATURE_CRYPTO 1
+#    endif
+#    ifndef __ARM_FEATURE_AES
+#        define __ARM_FEATURE_AES 1
+#    endif
+#    ifndef __ARM_FEATURE_SHA3
+#        define __ARM_FEATURE_SHA3 1
+#    endif
+
+#    include <arm_neon.h>
+
+#    ifdef __clang__
+#        pragma clang attribute push(__attribute__((target("neon,crypto,aes,sha3"))), \
+                                     apply_to = function)
+#    elif defined(__GNUC__)
+#        if __GNUC__ < 14
+#            pragma GCC target("arch=armv8.2-a+simd+crypto+sha3")
+#        else
+#            pragma GCC target("+simd+crypto+sha3")
+#        endif
+#    endif
+
+#    define AES_BLOCK_LENGTH 32
+#    define AES_INVERT_STATE37 1
+
+typedef struct {
+    uint8x16_t b0;
+    uint8x16_t b1;
+} aes_block_t;
+
+static const uint8_t ones_arr[] = { 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU };
+
+static inline uint8x16x2_t
+fresh_ones_pair(void)
+{
+    // The AESE instruction first operand register is both an input and output
+    // to the instruction. If the first operand is used in multiple places,
+    // this can therefore force compilers to emit MOV instructions to duplicate
+    // the value. In AES_ENC0 we use a zero register which would ordinarily
+    // have this problem since the compiler can merge the zero constants
+    // together and reuse them, however compilers typically treat this as a
+    // special case since materializing zero is a zero-cost instruction on many
+    // micro-architectures. For AES_ENC1 we cannot use this trick:
+    // materializing 0xFF is not usually zero-cost so compilers do not treat it
+    // specially, however since this region of the code is so heavy in vector
+    // arithmetic, inserting an additional load instruction here is
+    // effectively free.
+    uint8x16x2_t ret;
+    __asm volatile("ldp %q0, %q1, [%2]": "=w"(ret.val[0]), "=w"(ret.val[1]): "r"(ones_arr));
+    return ret;
+}
+
+static inline aes_block_t
+AES_BLOCK_NOT(const aes_block_t a)
+{
+    return (aes_block_t) { vmvnq_u8(a.b0), vmvnq_u8(a.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XNOR(const aes_block_t a, const aes_block_t b)
+{
+    const uint8x16_t ones = vmovq_n_u8(0xff);
+
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, ones), veor3q_u8(a.b1, b.b1, ones) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR3(const aes_block_t a, const aes_block_t b, const aes_block_t c)
+{
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, c.b0), veor3q_u8(a.b1, b.b1, c.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_AND(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD(const uint8_t *a)
+{
+    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
+{
+    const uint8x16_t t = vreinterpretq_u8_u64(vsetq_lane_u64((a), vmovq_n_u64(b), 1));
+    return (aes_block_t) { t, t };
+}
+
+static inline void
+AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
+{
+    vst1q_u8(a, b.b0);
+    vst1q_u8(a + 16, b.b1);
+}
+
+static inline aes_block_t
+AES_ENC0(const aes_block_t a)
+{
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b0)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b1)) };
+}
+
+static inline aes_block_t
+AES_ENC1(const aes_block_t a)
+{
+    uint8x16x2_t ones = fresh_ones_pair();
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(ones.val[0], a.b0)),
+                           vaesmcq_u8(vaeseq_u8(ones.val[1], a.b1)) };
+}
+
+static inline aes_block_t
+AES_ENC(const aes_block_t a, const aes_block_t b)
+{
+    return AES_BLOCK_XOR(AES_ENC0(a), b);
+}
+
+static inline void
+aegis128x2_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
+{
+    // Apply bitwise-NOT to state[3] and state[7] to allow us to use the Arm
+    // SHA3 BCAX instruction.
+    aes_block_t enc7 = AES_ENC1(state[7]);
+    aes_block_t enc3 = AES_ENC1(state[3]);
+
+    state[7] = AES_BLOCK_XOR(AES_ENC0(state[6]), state[7]);
+    state[6] = AES_BLOCK_XOR(AES_ENC0(state[5]), state[6]);
+    state[5] = AES_BLOCK_XOR(AES_ENC0(state[4]), state[5]);
+    state[4] = AES_BLOCK_XOR3(enc3, state[4], d2);
+    state[3] = AES_BLOCK_XOR(AES_ENC0(state[2]), state[3]);
+    state[2] = AES_BLOCK_XOR(AES_ENC0(state[1]), state[2]);
+    state[1] = AES_BLOCK_XOR(AES_ENC0(state[0]), state[1]);
+    state[0] = AES_BLOCK_XOR3(enc7, state[0], d1);
+}
+
+#    include "aegis128x2_common.h"
+
+struct aegis128x2_implementation aegis128x2_neon_sha3_implementation = {
+    .encrypt_detached        = encrypt_detached,
+    .decrypt_detached        = decrypt_detached,
+    .encrypt_unauthenticated = encrypt_unauthenticated,
+    .decrypt_unauthenticated = decrypt_unauthenticated,
+    .stream                  = stream,
+    .state_init              = state_init,
+    .state_encrypt_update    = state_encrypt_update,
+    .state_encrypt_final     = state_encrypt_final,
+    .state_decrypt_update    = state_decrypt_update,
+    .state_decrypt_final     = state_decrypt_final,
+    .state_mac_init          = state_mac_init,
+    .state_mac_update        = state_mac_update,
+    .state_mac_final         = state_mac_final,
+    .state_mac_reset         = state_mac_reset,
+    .state_mac_clone         = state_mac_clone,
+};
+
+#    ifdef __clang__
+#        pragma clang attribute pop
+#    endif
+
+#endif

--- a/src/aegis128x2/aegis128x2_neon_sha3.h
+++ b/src/aegis128x2/aegis128x2_neon_sha3.h
@@ -1,0 +1,9 @@
+#ifndef aegis128x2_neon_sha3_H
+#define aegis128x2_neon_sha3_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis128x2_implementation aegis128x2_neon_sha3_implementation;
+
+#endif

--- a/src/aegis128x2/implementations.h
+++ b/src/aegis128x2/implementations.h
@@ -7,11 +7,12 @@
 #include "aegis128x2.h"
 
 /* Namespacing to avoid conflicts with libsodium */
-#define aegis128x2_soft_implementation     libaegis_aegis128x2_soft_implementation
-#define aegis128x2_aesni_implementation    libaegis_aegis128x2_aesni_implementation
-#define aegis128x2_neon_aes_implementation libaegis_aegis128x2_neon_aes_implementation
-#define aegis128x2_altivec_implementation  libaegis_aegis128x2_altivec_implementation
-#define aegis128x2_avx2_implementation     libaegis_aegis128x2_avx2_implementation
+#define aegis128x2_soft_implementation      libaegis_aegis128x2_soft_implementation
+#define aegis128x2_aesni_implementation     libaegis_aegis128x2_aesni_implementation
+#define aegis128x2_neon_aes_implementation  libaegis_aegis128x2_neon_aes_implementation
+#define aegis128x2_neon_sha3_implementation libaegis_aegis128x2_neon_sha3_implementation
+#define aegis128x2_altivec_implementation   libaegis_aegis128x2_altivec_implementation
+#define aegis128x2_avx2_implementation      libaegis_aegis128x2_avx2_implementation
 
 typedef struct aegis128x2_implementation {
     int (*encrypt_detached)(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size_t mlen,

--- a/src/aegis128x4/aegis128x4.c
+++ b/src/aegis128x4/aegis128x4.c
@@ -9,6 +9,7 @@
 #include "aegis128x4_avx2.h"
 #include "aegis128x4_avx512.h"
 #include "aegis128x4_neon_aes.h"
+#include "aegis128x4_neon_sha3.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis128x4_soft.h"
@@ -218,6 +219,10 @@ aegis128x4_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
+    if (aegis_runtime_has_neon_sha3()) {
+        implementation = &aegis128x4_neon_sha3_implementation;
+        return 0;
+    }
     if (aegis_runtime_has_neon_aes()) {
         implementation = &aegis128x4_neon_aes_implementation;
         return 0;

--- a/src/aegis128x4/aegis128x4_common.h
+++ b/src/aegis128x4/aegis128x4_common.h
@@ -1,6 +1,13 @@
 #define RATE      128
 #define ALIGNMENT 64
 
+// If not inverting state[3] and state[7], treat bitwise-NOT operations as
+// no-ops.
+#ifndef AES_INVERT_STATE37
+#    define AES_BLOCK_NOT(A) (A)
+#    define AES_BLOCK_XNOR(A, B) AES_BLOCK_XOR((A), (B))
+#endif
+
 typedef aes_block_t aegis_blocks[8];
 
 static inline void
@@ -56,11 +63,11 @@ aegis128x4_init(const uint8_t *key, const uint8_t *nonce, aes_block_t *const sta
     state[0] = AES_BLOCK_XOR(k, n);
     state[1] = c1;
     state[2] = c0;
-    state[3] = c1;
+    state[3] = AES_BLOCK_NOT(c1);
     state[4] = AES_BLOCK_XOR(k, n);
     state[5] = AES_BLOCK_XOR(k, c0);
     state[6] = AES_BLOCK_XOR(k, c1);
-    state[7] = AES_BLOCK_XOR(k, c0);
+    state[7] = AES_BLOCK_XNOR(k, c0);
     for (i = 0; i < 10; i++) {
         state[3] = AES_BLOCK_XOR(state[3], context);
         state[7] = AES_BLOCK_XOR(state[7], context);
@@ -85,7 +92,7 @@ aegis128x4_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
 
     if (maclen == 16) {
         tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac_multi_0, tmp);
         for (i = 0; i < 16; i++) {
@@ -93,7 +100,7 @@ aegis128x4_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
                      mac_multi_0[3 * 16 + i];
         }
     } else if (maclen == 32) {
-        tmp = AES_BLOCK_XOR(state[3], state[2]);
+        tmp = AES_BLOCK_XNOR(state[3], state[2]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac_multi_0, tmp);
         for (i = 0; i < 16; i++) {
@@ -101,7 +108,7 @@ aegis128x4_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
                      mac_multi_0[3 * 16 + i];
         }
 
-        tmp = AES_BLOCK_XOR(state[7], state[6]);
+        tmp = AES_BLOCK_XNOR(state[7], state[6]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[5], state[4]));
         AES_BLOCK_STORE(mac_multi_1, tmp);
         for (i = 0; i < 16; i++) {
@@ -139,9 +146,9 @@ aegis128x4_squeeze_keystream(uint8_t *const dst, aes_block_t *const state)
     aes_block_t tmp0, tmp1;
 
     tmp0 = AES_BLOCK_XOR(state[6], state[1]);
-    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], state[3]));
+    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     tmp1 = AES_BLOCK_XOR(state[5], state[2]);
-    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], state[7]));
+    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, tmp0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, tmp1);
 }
@@ -158,8 +165,8 @@ aegis128x4_enc(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     tmp0 = AES_BLOCK_XOR(tmp0, state[1]);
     tmp1 = AES_BLOCK_XOR(msg1, state[5]);
     tmp1 = AES_BLOCK_XOR(tmp1, state[2]);
-    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], state[3]));
-    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], state[7]));
+    tmp0 = AES_BLOCK_XOR(tmp0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    tmp1 = AES_BLOCK_XOR(tmp1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, tmp0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, tmp1);
 
@@ -177,8 +184,8 @@ aegis128x4_dec(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     msg0 = AES_BLOCK_XOR(msg0, state[1]);
     msg1 = AES_BLOCK_XOR(msg1, state[5]);
     msg1 = AES_BLOCK_XOR(msg1, state[2]);
-    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], state[3]));
-    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], state[7]));
+    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(dst, msg0);
     AES_BLOCK_STORE(dst + AES_BLOCK_LENGTH, msg1);
 
@@ -201,8 +208,8 @@ aegis128x4_declast(uint8_t *const dst, const uint8_t *const src, size_t len,
     msg0 = AES_BLOCK_XOR(msg0, state[1]);
     msg1 = AES_BLOCK_XOR(msg1, state[5]);
     msg1 = AES_BLOCK_XOR(msg1, state[2]);
-    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], state[3]));
-    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], state[7]));
+    msg0 = AES_BLOCK_XOR(msg0, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
+    msg1 = AES_BLOCK_XOR(msg1, AES_BLOCK_AND(state[6], AES_BLOCK_NOT(state[7])));
     AES_BLOCK_STORE(pad, msg0);
     AES_BLOCK_STORE(pad + AES_BLOCK_LENGTH, msg1);
 
@@ -235,7 +242,7 @@ aegis128x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
     if (maclen == 16) {
 #if AES_BLOCK_LENGTH > 16
         tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         for (i = 0; i < d / 2; i++) {
@@ -250,16 +257,16 @@ aegis128x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
         }
 #endif
         tmp = AES_BLOCK_XOR(state[6], AES_BLOCK_XOR(state[5], state[4]));
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
     } else if (maclen == 32) {
 #if AES_BLOCK_LENGTH > 16
-        tmp = AES_BLOCK_XOR(state[3], state[2]);
+        tmp = AES_BLOCK_XNOR(state[3], state[2]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
-        tmp = AES_BLOCK_XOR(state[7], state[6]);
+        tmp = AES_BLOCK_XNOR(state[7], state[6]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[5], state[4]));
         AES_BLOCK_STORE(t + AES_BLOCK_LENGTH, tmp);
         for (i = 1; i < d; i++) {
@@ -273,11 +280,11 @@ aegis128x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
             aegis128x4_update(state, tmp, tmp);
         }
 #endif
-        tmp = AES_BLOCK_XOR(state[3], state[2]);
+        tmp = AES_BLOCK_XNOR(state[3], state[2]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
-        tmp = AES_BLOCK_XOR(state[7], state[6]);
+        tmp = AES_BLOCK_XNOR(state[7], state[6]);
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[5], state[4]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac + 16, t, 16);

--- a/src/aegis128x4/aegis128x4_neon_sha3.c
+++ b/src/aegis128x4/aegis128x4_neon_sha3.c
@@ -1,0 +1,194 @@
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#    include <stddef.h>
+#    include <stdint.h>
+
+#    include "../common/common.h"
+#    include "aegis128x4.h"
+#    include "aegis128x4_neon_sha3.h"
+
+#    ifndef __ARM_FEATURE_CRYPTO
+#        define __ARM_FEATURE_CRYPTO 1
+#    endif
+#    ifndef __ARM_FEATURE_AES
+#        define __ARM_FEATURE_AES 1
+#    endif
+#    ifndef __ARM_FEATURE_SHA3
+#        define __ARM_FEATURE_SHA3 1
+#    endif
+
+#    include <arm_neon.h>
+
+#    ifdef __clang__
+#        pragma clang attribute push(__attribute__((target("neon,crypto,aes,sha3"))), \
+                                     apply_to = function)
+#    elif defined(__GNUC__)
+#        if __GNUC__ < 14
+#            pragma GCC target("arch=armv8.2-a+simd+crypto+sha3")
+#        else
+#            pragma GCC target("+simd+crypto+sha3")
+#        endif
+#    endif
+
+#    define AES_BLOCK_LENGTH 64
+#    define AES_INVERT_STATE37 1
+
+typedef struct {
+    uint8x16_t b0;
+    uint8x16_t b1;
+    uint8x16_t b2;
+    uint8x16_t b3;
+} aes_block_t;
+
+static const uint8_t ones_arr[] = { 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU };
+
+static inline uint8x16x2_t
+fresh_ones_pair(void)
+{
+    // The AESE instruction first operand register is both an input and output
+    // to the instruction. If the first operand is used in multiple places,
+    // this can therefore force compilers to emit MOV instructions to duplicate
+    // the value. In AES_ENC0 we use a zero register which would ordinarily
+    // have this problem since the compiler can merge the zero constants
+    // together and reuse them, however compilers typically treat this as a
+    // special case since materializing zero is a zero-cost instruction on many
+    // micro-architectures. For AES_ENC1 we cannot use this trick:
+    // materializing 0xFF is not usually zero-cost so compilers do not treat it
+    // specially, however since this region of the code is so heavy in vector
+    // arithmetic, inserting an additional load instruction here is
+    // effectively free.
+    uint8x16x2_t ret;
+    __asm volatile("ldp %q0, %q1, [%2]": "=w"(ret.val[0]), "=w"(ret.val[1]): "r"(ones_arr));
+    return ret;
+}
+
+static inline aes_block_t
+AES_BLOCK_NOT(const aes_block_t a)
+{
+    return (aes_block_t) { vmvnq_u8(a.b0), vmvnq_u8(a.b1), vmvnq_u8(a.b2), vmvnq_u8(a.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1), veorq_u8(a.b2, b.b2),
+                           veorq_u8(a.b3, b.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XNOR(const aes_block_t a, const aes_block_t b)
+{
+    const uint8x16_t ones = vmovq_n_u8(0xff);
+
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, ones), veor3q_u8(a.b1, b.b1, ones),
+                           veor3q_u8(a.b2, b.b2, ones), veor3q_u8(a.b3, b.b3, ones) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR3(const aes_block_t a, const aes_block_t b, const aes_block_t c)
+{
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, c.b0), veor3q_u8(a.b1, b.b1, c.b1),
+                           veor3q_u8(a.b2, b.b2, c.b2), veor3q_u8(a.b3, b.b3, c.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_AND(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1), vandq_u8(a.b2, b.b2),
+                           vandq_u8(a.b3, b.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD(const uint8_t *a)
+{
+    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16), vld1q_u8(a + 32), vld1q_u8(a + 48) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
+{
+    const uint8x16_t t = vreinterpretq_u8_u64(vsetq_lane_u64((a), vmovq_n_u64(b), 1));
+    return (aes_block_t) { t, t, t, t };
+}
+
+static inline void
+AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
+{
+    vst1q_u8(a, b.b0);
+    vst1q_u8(a + 16, b.b1);
+    vst1q_u8(a + 32, b.b2);
+    vst1q_u8(a + 48, b.b3);
+}
+
+static inline aes_block_t
+AES_ENC0(const aes_block_t a)
+{
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b0)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b1)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b2)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b3)) };
+}
+
+static inline aes_block_t
+AES_ENC1(const aes_block_t a)
+{
+    uint8x16x2_t ones01 = fresh_ones_pair();
+    uint8x16x2_t ones23 = fresh_ones_pair();
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(ones01.val[0], a.b0)),
+                           vaesmcq_u8(vaeseq_u8(ones01.val[1], a.b1)),
+                           vaesmcq_u8(vaeseq_u8(ones23.val[0], a.b2)),
+                           vaesmcq_u8(vaeseq_u8(ones23.val[1], a.b3)) };
+}
+
+static inline aes_block_t
+AES_ENC(const aes_block_t a, const aes_block_t b)
+{
+    return AES_BLOCK_XOR(AES_ENC0(a), b);
+}
+
+static inline void
+aegis128x4_update(aes_block_t *const state, const aes_block_t d1, const aes_block_t d2)
+{
+    // Apply bitwise-NOT to state[3] and state[7] to allow us to use the Arm
+    // SHA3 BCAX instruction.
+    aes_block_t enc3 = AES_ENC1(state[3]);
+    aes_block_t enc7 = AES_ENC1(state[7]);
+
+    state[7] = AES_BLOCK_XOR(AES_ENC0(state[6]), state[7]);
+    state[6] = AES_BLOCK_XOR(AES_ENC0(state[5]), state[6]);
+    state[5] = AES_BLOCK_XOR(AES_ENC0(state[4]), state[5]);
+    state[4] = AES_BLOCK_XOR3(enc3, state[4], d2);
+    state[3] = AES_BLOCK_XOR(AES_ENC0(state[2]), state[3]);
+    state[2] = AES_BLOCK_XOR(AES_ENC0(state[1]), state[2]);
+    state[1] = AES_BLOCK_XOR(AES_ENC0(state[0]), state[1]);
+    state[0] = AES_BLOCK_XOR3(enc7, state[0], d1);
+}
+
+#    include "aegis128x4_common.h"
+
+struct aegis128x4_implementation aegis128x4_neon_sha3_implementation = {
+    .encrypt_detached        = encrypt_detached,
+    .decrypt_detached        = decrypt_detached,
+    .encrypt_unauthenticated = encrypt_unauthenticated,
+    .decrypt_unauthenticated = decrypt_unauthenticated,
+    .stream                  = stream,
+    .state_init              = state_init,
+    .state_encrypt_update    = state_encrypt_update,
+    .state_encrypt_final     = state_encrypt_final,
+    .state_decrypt_update    = state_decrypt_update,
+    .state_decrypt_final     = state_decrypt_final,
+    .state_mac_init          = state_mac_init,
+    .state_mac_update        = state_mac_update,
+    .state_mac_final         = state_mac_final,
+    .state_mac_reset         = state_mac_reset,
+    .state_mac_clone         = state_mac_clone,
+};
+
+#    ifdef __clang__
+#        pragma clang attribute pop
+#    endif
+
+#endif

--- a/src/aegis128x4/aegis128x4_neon_sha3.h
+++ b/src/aegis128x4/aegis128x4_neon_sha3.h
@@ -1,0 +1,9 @@
+#ifndef aegis128x4_neon_sha3_H
+#define aegis128x4_neon_sha3_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis128x4_implementation aegis128x4_neon_sha3_implementation;
+
+#endif

--- a/src/aegis128x4/implementations.h
+++ b/src/aegis128x4/implementations.h
@@ -7,12 +7,13 @@
 #include "aegis128x4.h"
 
 /* Namespacing to avoid conflicts with libsodium */
-#define aegis128x4_soft_implementation     libaegis_aegis128x4_soft_implementation
-#define aegis128x4_aesni_implementation    libaegis_aegis128x4_aesni_implementation
-#define aegis128x4_neon_aes_implementation libaegis_aegis128x4_neon_aes_implementation
-#define aegis128x4_altivec_implementation  libaegis_aegis128x4_altivec_implementation
-#define aegis128x4_avx2_implementation     libaegis_aegis128x4_avx2_implementation
-#define aegis128x4_avx512_implementation   libaegis_aegis128x4_avx512_implementation
+#define aegis128x4_soft_implementation      libaegis_aegis128x4_soft_implementation
+#define aegis128x4_aesni_implementation     libaegis_aegis128x4_aesni_implementation
+#define aegis128x4_neon_aes_implementation  libaegis_aegis128x4_neon_aes_implementation
+#define aegis128x4_neon_sha3_implementation libaegis_aegis128x4_neon_sha3_implementation
+#define aegis128x4_altivec_implementation   libaegis_aegis128x4_altivec_implementation
+#define aegis128x4_avx2_implementation      libaegis_aegis128x4_avx2_implementation
+#define aegis128x4_avx512_implementation    libaegis_aegis128x4_avx512_implementation
 
 typedef struct aegis128x4_implementation {
     int (*encrypt_detached)(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size_t mlen,

--- a/src/aegis256/aegis256.c
+++ b/src/aegis256/aegis256.c
@@ -7,6 +7,7 @@
 #include "aegis256_aesni.h"
 #include "aegis256_altivec.h"
 #include "aegis256_neon_aes.h"
+#include "aegis256_neon_sha3.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis256_soft.h"
@@ -216,6 +217,10 @@ aegis256_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
+    if (aegis_runtime_has_neon_sha3()) {
+        implementation = &aegis256_neon_sha3_implementation;
+        return 0;
+    }
     if (aegis_runtime_has_neon_aes()) {
         implementation = &aegis256_neon_aes_implementation;
         return 0;

--- a/src/aegis256/aegis256_common.h
+++ b/src/aegis256/aegis256_common.h
@@ -1,6 +1,12 @@
 #define RATE      16
 #define ALIGNMENT 16
 
+// If not inverting state[3], treat bitwise-NOT operations as no-ops.
+#ifndef AES_INVERT_STATE3
+#    define AES_BLOCK_NOT(A) (A)
+#    define AES_BLOCK_XNOR(A, B) AES_BLOCK_XOR((A), (B))
+#endif
+
 typedef aes_block_t aegis_blocks[6];
 
 static inline void
@@ -26,7 +32,7 @@ aegis256_init(const uint8_t *key, const uint8_t *nonce, aes_block_t *const state
     state[0] = k0_n0;
     state[1] = k1_n1;
     state[2] = c1;
-    state[3] = c0;
+    state[3] = AES_BLOCK_NOT(c0);
     state[4] = AES_BLOCK_XOR(k0, c0);
     state[5] = AES_BLOCK_XOR(k1, c1);
     for (i = 0; i < 4; i++) {
@@ -44,7 +50,7 @@ aegis256_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_blo
     int         i;
 
     tmp = AES_BLOCK_LOAD_64x2(mlen << 3, adlen << 3);
-    tmp = AES_BLOCK_XOR(tmp, state[3]);
+    tmp = AES_BLOCK_XNOR(tmp, state[3]);
 
     for (i = 0; i < 7; i++) {
         aegis256_update(state, tmp);
@@ -52,13 +58,13 @@ aegis256_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_blo
 
     if (maclen == 16) {
         tmp = AES_BLOCK_XOR(state[5], state[4]);
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac, tmp);
     } else if (maclen == 32) {
         tmp = AES_BLOCK_XOR(AES_BLOCK_XOR(state[2], state[1]), state[0]);
         AES_BLOCK_STORE(mac, tmp);
-        tmp = AES_BLOCK_XOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
+        tmp = AES_BLOCK_XNOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
         AES_BLOCK_STORE(mac + 16, tmp);
     } else {
         memset(mac, 0, maclen);
@@ -90,7 +96,7 @@ aegis256_squeeze_keystream(uint8_t *const dst, aes_block_t *const state)
 
     tmp = AES_BLOCK_XOR(state[5], state[4]);
     tmp = AES_BLOCK_XOR(tmp, state[1]);
-    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], state[3]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, tmp);
 }
 
@@ -104,7 +110,7 @@ aegis256_enc(uint8_t *const dst, const uint8_t *const src, aes_block_t *const st
     tmp = AES_BLOCK_XOR(msg, state[5]);
     tmp = AES_BLOCK_XOR(tmp, state[4]);
     tmp = AES_BLOCK_XOR(tmp, state[1]);
-    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], state[3]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, tmp);
 
     aegis256_update(state, msg);
@@ -119,7 +125,7 @@ aegis256_dec(uint8_t *const dst, const uint8_t *const src, aes_block_t *const st
     msg = AES_BLOCK_XOR(msg, state[5]);
     msg = AES_BLOCK_XOR(msg, state[4]);
     msg = AES_BLOCK_XOR(msg, state[1]);
-    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], state[3]));
+    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, msg);
 
     aegis256_update(state, msg);
@@ -138,7 +144,7 @@ aegis256_declast(uint8_t *const dst, const uint8_t *const src, size_t len, aes_b
     msg = AES_BLOCK_XOR(msg, state[5]);
     msg = AES_BLOCK_XOR(msg, state[4]);
     msg = AES_BLOCK_XOR(msg, state[1]);
-    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], state[3]));
+    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(pad, msg);
 
     memset(pad + len, 0, sizeof pad - len);

--- a/src/aegis256/aegis256_neon_sha3.c
+++ b/src/aegis256/aegis256_neon_sha3.c
@@ -1,0 +1,117 @@
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#    include <stddef.h>
+#    include <stdint.h>
+
+#    include "../common/common.h"
+#    include "aegis256.h"
+#    include "aegis256_neon_sha3.h"
+
+#    ifndef __ARM_FEATURE_CRYPTO
+#        define __ARM_FEATURE_CRYPTO 1
+#    endif
+#    ifndef __ARM_FEATURE_AES
+#        define __ARM_FEATURE_AES 1
+#    endif
+#    ifndef __ARM_FEATURE_SHA3
+#        define __ARM_FEATURE_SHA3 1
+#    endif
+
+#    include <arm_neon.h>
+
+#    ifdef __clang__
+#        pragma clang attribute push(__attribute__((target("neon,crypto,aes,sha3"))), \
+                                     apply_to = function)
+#    elif defined(__GNUC__)
+#        if __GNUC__ < 14
+#            pragma GCC target("arch=armv8.2-a+simd+crypto+sha3")
+#        else
+#            pragma GCC target("+simd+crypto+sha3")
+#        endif
+#    endif
+
+#    define AES_BLOCK_LENGTH 16
+#    define AES_INVERT_STATE3 1
+
+typedef uint8x16_t aes_block_t;
+
+static const uint8_t ones_arr[] = { 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU };
+
+static inline uint8x16_t
+fresh_ones(void)
+{
+    // The AESE instruction first operand register is both an input and output
+    // to the instruction. If the first operand is used in multiple places,
+    // this can therefore force compilers to emit MOV instructions to duplicate
+    // the value. In AES_ENC0 we use a zero register which would ordinarily
+    // have this problem since the compiler can merge the zero constants
+    // together and reuse them, however compilers typically treat this as a
+    // special case since materializing zero is a zero-cost instruction on many
+    // micro-architectures. For AES_ENC1 we cannot use this trick:
+    // materializing 0xFF is not usually zero-cost so compilers do not treat it
+    // specially, however since this region of the code is so heavy in vector
+    // arithmetic, inserting an additional load instruction here is
+    // effectively free.
+    uint8x16_t ret;
+    __asm volatile("ldr %q0, %1": "=w"(ret): "m"(ones_arr));
+    return ret;
+}
+
+#    define AES_BLOCK_NOT(A)          vmvnq_u8((A))
+#    define AES_BLOCK_XOR(A, B)       veorq_u8((A), (B))
+#    define AES_BLOCK_XNOR(A, B)      veor3q_u8((A), (B), vmovq_n_u8(0xFF))
+#    define AES_BLOCK_XOR3(A, B, C)   veor3q_u8((A), (B), (C))
+#    define AES_BLOCK_AND(A, B)       vandq_u8((A), (B))
+#    define AES_BLOCK_LOAD(A)         vld1q_u8(A)
+#    define AES_BLOCK_LOAD_64x2(A, B) vreinterpretq_u8_u64(vsetq_lane_u64((A), vmovq_n_u64(B), 1))
+#    define AES_BLOCK_STORE(A, B)     vst1q_u8((A), (B))
+#    define AES_ENC0(A)               vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), (A)))
+#    define AES_ENC1(A)               vaesmcq_u8(vaeseq_u8(fresh_ones(), (A)))
+#    define AES_ENC(A, B)             AES_BLOCK_XOR(AES_ENC0(A), (B))
+
+static inline void
+aegis256_update(aes_block_t *const state, const aes_block_t d)
+{
+    // Apply bitwise-NOT to state[3] to allow us to use the Arm SHA3 BCAX
+    // instruction.
+    aes_block_t enc5 = AES_ENC0(state[5]);
+    aes_block_t enc4 = AES_ENC0(state[4]);
+    aes_block_t enc3 = AES_ENC1(state[3]);
+    aes_block_t enc2 = AES_ENC0(state[2]);
+    aes_block_t enc1 = AES_ENC0(state[1]);
+    aes_block_t enc0 = AES_ENC0(state[0]);
+
+    state[5] = AES_BLOCK_XOR(enc4, state[5]);
+    state[4] = AES_BLOCK_XOR(enc3, state[4]);
+    state[3] = AES_BLOCK_XOR(enc2, state[3]);
+    state[2] = AES_BLOCK_XOR(enc1, state[2]);
+    state[1] = AES_BLOCK_XOR(enc0, state[1]);
+    state[0] = AES_BLOCK_XOR3(enc5, state[0], d);
+}
+
+#    include "aegis256_common.h"
+
+struct aegis256_implementation aegis256_neon_sha3_implementation = {
+    .encrypt_detached        = encrypt_detached,
+    .decrypt_detached        = decrypt_detached,
+    .encrypt_unauthenticated = encrypt_unauthenticated,
+    .decrypt_unauthenticated = decrypt_unauthenticated,
+    .stream                  = stream,
+    .state_init              = state_init,
+    .state_encrypt_update    = state_encrypt_update,
+    .state_encrypt_final     = state_encrypt_final,
+    .state_decrypt_update    = state_decrypt_update,
+    .state_decrypt_final     = state_decrypt_final,
+    .state_mac_init          = state_mac_init,
+    .state_mac_update        = state_mac_update,
+    .state_mac_final         = state_mac_final,
+    .state_mac_reset         = state_mac_reset,
+    .state_mac_clone         = state_mac_clone,
+};
+
+#    ifdef __clang__
+#        pragma clang attribute pop
+#    endif
+
+#endif

--- a/src/aegis256/aegis256_neon_sha3.h
+++ b/src/aegis256/aegis256_neon_sha3.h
@@ -1,0 +1,9 @@
+#ifndef aegis256_neon_sha3_H
+#define aegis256_neon_sha3_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis256_implementation aegis256_neon_sha3_implementation;
+
+#endif

--- a/src/aegis256/implementations.h
+++ b/src/aegis256/implementations.h
@@ -7,10 +7,11 @@
 #include "aegis256.h"
 
 /* Namespacing to avoid conflicts with libsodium */
-#define aegis256_soft_implementation     libaegis_aegis256_soft_implementation
-#define aegis256_aesni_implementation    libaegis_aegis256_aesni_implementation
-#define aegis256_neon_aes_implementation libaegis_aegis256_neon_aes_implementation
-#define aegis256_altivec_implementation  libaegis_aegis256_altivec_implementation
+#define aegis256_soft_implementation      libaegis_aegis256_soft_implementation
+#define aegis256_aesni_implementation     libaegis_aegis256_aesni_implementation
+#define aegis256_neon_aes_implementation  libaegis_aegis256_neon_aes_implementation
+#define aegis256_neon_sha3_implementation libaegis_aegis256_neon_sha3_implementation
+#define aegis256_altivec_implementation   libaegis_aegis256_altivec_implementation
 
 typedef struct aegis256_implementation {
     int (*encrypt_detached)(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size_t mlen,

--- a/src/aegis256x2/aegis256x2.c
+++ b/src/aegis256x2/aegis256x2.c
@@ -8,6 +8,7 @@
 #include "aegis256x2_altivec.h"
 #include "aegis256x2_avx2.h"
 #include "aegis256x2_neon_aes.h"
+#include "aegis256x2_neon_sha3.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis256x2_soft.h"
@@ -217,6 +218,10 @@ aegis256x2_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
+    if (aegis_runtime_has_neon_sha3()) {
+        implementation = &aegis256x2_neon_sha3_implementation;
+        return 0;
+    }
     if (aegis_runtime_has_neon_aes()) {
         implementation = &aegis256x2_neon_aes_implementation;
         return 0;

--- a/src/aegis256x2/aegis256x2_common.h
+++ b/src/aegis256x2/aegis256x2_common.h
@@ -1,6 +1,12 @@
 #define RATE      32
 #define ALIGNMENT 32
 
+// If not inverting state[3], treat bitwise-NOT operations as no-ops.
+#ifndef AES_INVERT_STATE3
+#    define AES_BLOCK_NOT(A) (A)
+#    define AES_BLOCK_XNOR(A, B) AES_BLOCK_XOR((A), (B))
+#endif
+
 typedef aes_block_t aegis_blocks[6];
 
 static inline void
@@ -54,7 +60,7 @@ aegis256x2_init(const uint8_t *key, const uint8_t *nonce, aes_block_t *const sta
     state[0] = k0_n0;
     state[1] = k1_n1;
     state[2] = c1;
-    state[3] = c0;
+    state[3] = AES_BLOCK_NOT(c0);
     state[4] = AES_BLOCK_XOR(k0, c0);
     state[5] = AES_BLOCK_XOR(k1, c1);
     for (i = 0; i < 4; i++) {
@@ -82,7 +88,7 @@ aegis256x2_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
     int         i;
 
     tmp = AES_BLOCK_LOAD_64x2(mlen << 3, adlen << 3);
-    tmp = AES_BLOCK_XOR(tmp, state[3]);
+    tmp = AES_BLOCK_XNOR(tmp, state[3]);
 
     for (i = 0; i < 7; i++) {
         aegis256x2_update(state, tmp);
@@ -90,7 +96,7 @@ aegis256x2_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
 
     if (maclen == 16) {
         tmp = AES_BLOCK_XOR(state[5], state[4]);
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac_multi_0, tmp);
         for (i = 0; i < 16; i++) {
@@ -103,7 +109,7 @@ aegis256x2_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
             mac[i] = mac_multi_0[i] ^ mac_multi_0[1 * 16 + i];
         }
 
-        tmp = AES_BLOCK_XOR(state[5], AES_BLOCK_XOR(state[4], state[3]));
+        tmp = AES_BLOCK_XNOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
         AES_BLOCK_STORE(mac_multi_1, tmp);
         for (i = 0; i < 16; i++) {
             mac[i + 16] = mac_multi_1[i] ^ mac_multi_1[1 * 16 + i];
@@ -138,7 +144,7 @@ aegis256x2_squeeze_keystream(uint8_t *const dst, aes_block_t *const state)
 
     tmp = AES_BLOCK_XOR(state[5], state[4]);
     tmp = AES_BLOCK_XOR(tmp, state[1]);
-    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], state[3]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, tmp);
 }
 
@@ -152,7 +158,7 @@ aegis256x2_enc(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     tmp = AES_BLOCK_XOR(msg, state[5]);
     tmp = AES_BLOCK_XOR(tmp, state[4]);
     tmp = AES_BLOCK_XOR(tmp, state[1]);
-    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], state[3]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, tmp);
 
     aegis256x2_update(state, msg);
@@ -167,7 +173,7 @@ aegis256x2_dec(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     msg = AES_BLOCK_XOR(msg, state[5]);
     msg = AES_BLOCK_XOR(msg, state[4]);
     msg = AES_BLOCK_XOR(msg, state[1]);
-    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], state[3]));
+    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, msg);
 
     aegis256x2_update(state, msg);
@@ -187,7 +193,7 @@ aegis256x2_declast(uint8_t *const dst, const uint8_t *const src, size_t len,
     msg = AES_BLOCK_XOR(msg, state[5]);
     msg = AES_BLOCK_XOR(msg, state[4]);
     msg = AES_BLOCK_XOR(msg, state[1]);
-    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], state[3]));
+    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(pad, msg);
 
     memset(pad + len, 0, sizeof pad - len);
@@ -208,7 +214,7 @@ aegis256x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
     const int   d = AES_BLOCK_LENGTH / 16;
 
     tmp = AES_BLOCK_LOAD_64x2(maclen << 3, adlen << 3);
-    tmp = AES_BLOCK_XOR(tmp, state[3]);
+    tmp = AES_BLOCK_XNOR(tmp, state[3]);
 
     for (i = 0; i < 7; i++) {
         aegis256x2_update(state, tmp);
@@ -218,7 +224,7 @@ aegis256x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
     if (maclen == 16) {
 #if AES_BLOCK_LENGTH > 16
         tmp = AES_BLOCK_XOR(state[5], state[4]);
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
 
@@ -227,13 +233,13 @@ aegis256x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
             aegis256x2_absorb(r, state);
         }
         tmp = AES_BLOCK_LOAD_64x2(maclen << 3, d);
-        tmp = AES_BLOCK_XOR(tmp, state[3]);
+        tmp = AES_BLOCK_XNOR(tmp, state[3]);
         for (i = 0; i < 7; i++) {
             aegis256x2_update(state, tmp);
         }
 #endif
         tmp = AES_BLOCK_XOR(state[5], state[4]);
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
@@ -241,7 +247,7 @@ aegis256x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
 #if AES_BLOCK_LENGTH > 16
         tmp = AES_BLOCK_XOR(state[2], AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
-        tmp = AES_BLOCK_XOR(state[5], AES_BLOCK_XOR(state[4], state[3]));
+        tmp = AES_BLOCK_XNOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
         AES_BLOCK_STORE(t + AES_BLOCK_LENGTH, tmp);
         for (i = 1; i < d; i++) {
             memcpy(r, t + i * 16, 16);
@@ -250,7 +256,7 @@ aegis256x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
             aegis256x2_absorb(r, state);
         }
         tmp = AES_BLOCK_LOAD_64x2(maclen << 3, d);
-        tmp = AES_BLOCK_XOR(tmp, state[3]);
+        tmp = AES_BLOCK_XNOR(tmp, state[3]);
         for (i = 0; i < 7; i++) {
             aegis256x2_update(state, tmp);
         }
@@ -258,7 +264,7 @@ aegis256x2_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
         tmp = AES_BLOCK_XOR(state[2], AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
-        tmp = AES_BLOCK_XOR(state[5], AES_BLOCK_XOR(state[4], state[3]));
+        tmp = AES_BLOCK_XNOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac + 16, t, 16);
     } else {

--- a/src/aegis256x2/aegis256x2_neon_sha3.c
+++ b/src/aegis256x2/aegis256x2_neon_sha3.c
@@ -1,0 +1,178 @@
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#    include <stddef.h>
+#    include <stdint.h>
+
+#    include "../common/common.h"
+#    include "aegis256x2.h"
+#    include "aegis256x2_neon_sha3.h"
+
+#    ifndef __ARM_FEATURE_CRYPTO
+#        define __ARM_FEATURE_CRYPTO 1
+#    endif
+#    ifndef __ARM_FEATURE_AES
+#        define __ARM_FEATURE_AES 1
+#    endif
+#    ifndef __ARM_FEATURE_SHA3
+#        define __ARM_FEATURE_SHA3 1
+#    endif
+
+#    include <arm_neon.h>
+
+#    ifdef __clang__
+#        pragma clang attribute push(__attribute__((target("neon,crypto,aes,sha3"))), \
+                                     apply_to = function)
+#    elif defined(__GNUC__)
+#        if __GNUC__ < 14
+#            pragma GCC target("arch=armv8.2-a+simd+crypto+sha3")
+#        else
+#            pragma GCC target("+simd+crypto+sha3")
+#        endif
+#    endif
+
+#    define AES_BLOCK_LENGTH 32
+#    define AES_INVERT_STATE3 1
+
+typedef struct {
+    uint8x16_t b0;
+    uint8x16_t b1;
+} aes_block_t;
+
+static const uint8_t ones_arr[] = { 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU };
+
+static inline uint8x16x2_t
+fresh_ones_pair(void)
+{
+    // The AESE instruction first operand register is both an input and output
+    // to the instruction. If the first operand is used in multiple places,
+    // this can therefore force compilers to emit MOV instructions to duplicate
+    // the value. In AES_ENC0 we use a zero register which would ordinarily
+    // have this problem since the compiler can merge the zero constants
+    // together and reuse them, however compilers typically treat this as a
+    // special case since materializing zero is a zero-cost instruction on many
+    // micro-architectures. For AES_ENC1 we cannot use this trick:
+    // materializing 0xFF is not usually zero-cost so compilers do not treat it
+    // specially, however since this region of the code is so heavy in vector
+    // arithmetic, inserting an additional load instruction here is
+    // effectively free.
+    uint8x16x2_t ret;
+    __asm volatile("ldp %q0, %q1, [%2]": "=w"(ret.val[0]), "=w"(ret.val[1]): "r"(ones_arr));
+    return ret;
+}
+
+static inline aes_block_t
+AES_BLOCK_NOT(const aes_block_t a)
+{
+    return (aes_block_t) { vmvnq_u8(a.b0), vmvnq_u8(a.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XNOR(const aes_block_t a, const aes_block_t b)
+{
+    const uint8x16_t ones = vmovq_n_u8(0xff);
+
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, ones), veor3q_u8(a.b1, b.b1, ones) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR3(const aes_block_t a, const aes_block_t b, const aes_block_t c)
+{
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, c.b0), veor3q_u8(a.b1, b.b1, c.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_AND(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD(const uint8_t *a)
+{
+    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
+{
+    const uint8x16_t t = vreinterpretq_u8_u64(vsetq_lane_u64((a), vmovq_n_u64(b), 1));
+    return (aes_block_t) { t, t };
+}
+
+static inline void
+AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
+{
+    vst1q_u8(a, b.b0);
+    vst1q_u8(a + 16, b.b1);
+}
+
+static inline aes_block_t
+AES_ENC0(const aes_block_t a)
+{
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b0)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b1)) };
+}
+
+static inline aes_block_t
+AES_ENC1(const aes_block_t a)
+{
+    uint8x16x2_t ones = fresh_ones_pair();
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(ones.val[0], a.b0)),
+                           vaesmcq_u8(vaeseq_u8(ones.val[1], a.b1)) };
+}
+
+static inline aes_block_t
+AES_ENC(const aes_block_t a, const aes_block_t b)
+{
+    return AES_BLOCK_XOR(AES_ENC0(a), b);
+}
+
+static inline void
+aegis256x2_update(aes_block_t *const state, const aes_block_t d)
+{
+    aes_block_t tmp = state[5];
+
+    // Apply bitwise-NOT to state[3] to allow us to use the Arm SHA3 BCAX
+    // instruction.
+    state[5] = AES_BLOCK_XOR(AES_ENC0(state[4]), state[5]);
+    state[4] = AES_BLOCK_XOR(AES_ENC1(state[3]), state[4]);
+    state[3] = AES_BLOCK_XOR(AES_ENC0(state[2]), state[3]);
+    state[2] = AES_BLOCK_XOR(AES_ENC0(state[1]), state[2]);
+    state[1] = AES_BLOCK_XOR(AES_ENC0(state[0]), state[1]);
+    state[0] = AES_BLOCK_XOR3(AES_ENC0(tmp), state[0], d);
+}
+
+#    include "aegis256x2_common.h"
+
+struct aegis256x2_implementation aegis256x2_neon_sha3_implementation = {
+    .encrypt_detached        = encrypt_detached,
+    .decrypt_detached        = decrypt_detached,
+    .encrypt_unauthenticated = encrypt_unauthenticated,
+    .decrypt_unauthenticated = decrypt_unauthenticated,
+    .stream                  = stream,
+    .state_init              = state_init,
+    .state_encrypt_update    = state_encrypt_update,
+    .state_encrypt_final     = state_encrypt_final,
+    .state_decrypt_update    = state_decrypt_update,
+    .state_decrypt_final     = state_decrypt_final,
+    .state_mac_init          = state_mac_init,
+    .state_mac_update        = state_mac_update,
+    .state_mac_final         = state_mac_final,
+    .state_mac_reset         = state_mac_reset,
+    .state_mac_clone         = state_mac_clone,
+};
+
+#    ifdef __clang__
+#        pragma clang attribute pop
+#    endif
+
+#endif

--- a/src/aegis256x2/aegis256x2_neon_sha3.h
+++ b/src/aegis256x2/aegis256x2_neon_sha3.h
@@ -1,0 +1,9 @@
+#ifndef aegis256x2_neon_sha3_H
+#define aegis256x2_neon_sha3_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis256x2_implementation aegis256x2_neon_sha3_implementation;
+
+#endif

--- a/src/aegis256x2/implementations.h
+++ b/src/aegis256x2/implementations.h
@@ -7,11 +7,12 @@
 #include "aegis256x2.h"
 
 /* Namespacing to avoid conflicts with libsodium */
-#define aegis256x2_soft_implementation     libaegis_aegis256x2_soft_implementation
-#define aegis256x2_aesni_implementation    libaegis_aegis256x2_aesni_implementation
-#define aegis256x2_neon_aes_implementation libaegis_aegis256x2_neon_aes_implementation
-#define aegis256x2_altivec_implementation  libaegis_aegis256x2_altivec_implementation
-#define aegis256x2_avx2_implementation     libaegis_aegis256x2_avx2_implementation
+#define aegis256x2_soft_implementation      libaegis_aegis256x2_soft_implementation
+#define aegis256x2_aesni_implementation     libaegis_aegis256x2_aesni_implementation
+#define aegis256x2_neon_aes_implementation  libaegis_aegis256x2_neon_aes_implementation
+#define aegis256x2_neon_sha3_implementation libaegis_aegis256x2_neon_sha3_implementation
+#define aegis256x2_altivec_implementation   libaegis_aegis256x2_altivec_implementation
+#define aegis256x2_avx2_implementation      libaegis_aegis256x2_avx2_implementation
 
 typedef struct aegis256x2_implementation {
     int (*encrypt_detached)(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size_t mlen,

--- a/src/aegis256x4/aegis256x4.c
+++ b/src/aegis256x4/aegis256x4.c
@@ -9,6 +9,7 @@
 #include "aegis256x4_avx2.h"
 #include "aegis256x4_avx512.h"
 #include "aegis256x4_neon_aes.h"
+#include "aegis256x4_neon_sha3.h"
 
 #ifndef HAS_HW_AES
 #    include "aegis256x4_soft.h"
@@ -218,6 +219,10 @@ aegis256x4_pick_best_implementation(void)
 #endif
 
 #if defined(__aarch64__) || defined(_M_ARM64)
+    if (aegis_runtime_has_neon_sha3()) {
+        implementation = &aegis256x4_neon_sha3_implementation;
+        return 0;
+    }
     if (aegis_runtime_has_neon_aes()) {
         implementation = &aegis256x4_neon_aes_implementation;
         return 0;

--- a/src/aegis256x4/aegis256x4_common.h
+++ b/src/aegis256x4/aegis256x4_common.h
@@ -1,6 +1,12 @@
 #define RATE      64
 #define ALIGNMENT 64
 
+// If not inverting state[3], treat bitwise-NOT operations as no-ops.
+#ifndef AES_INVERT_STATE3
+#    define AES_BLOCK_NOT(A) (A)
+#    define AES_BLOCK_XNOR(A, B) AES_BLOCK_XOR((A), (B))
+#endif
+
 typedef aes_block_t aegis_blocks[6];
 
 static inline void
@@ -70,7 +76,7 @@ aegis256x4_init(const uint8_t *key, const uint8_t *nonce, aes_block_t *const sta
     state[0] = k0_n0;
     state[1] = k1_n1;
     state[2] = c1;
-    state[3] = c0;
+    state[3] = AES_BLOCK_NOT(c0);
     state[4] = AES_BLOCK_XOR(k0, c0);
     state[5] = AES_BLOCK_XOR(k1, c1);
     for (i = 0; i < 4; i++) {
@@ -98,7 +104,7 @@ aegis256x4_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
     int         i;
 
     tmp = AES_BLOCK_LOAD_64x2(mlen << 3, adlen << 3);
-    tmp = AES_BLOCK_XOR(tmp, state[3]);
+    tmp = AES_BLOCK_XNOR(tmp, state[3]);
 
     for (i = 0; i < 7; i++) {
         aegis256x4_update(state, tmp);
@@ -106,7 +112,7 @@ aegis256x4_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
 
     if (maclen == 16) {
         tmp = AES_BLOCK_XOR(state[5], state[4]);
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(mac_multi_0, tmp);
         for (i = 0; i < 16; i++) {
@@ -121,7 +127,7 @@ aegis256x4_mac(uint8_t *mac, size_t maclen, uint64_t adlen, uint64_t mlen, aes_b
                      mac_multi_0[3 * 16 + i];
         }
 
-        tmp = AES_BLOCK_XOR(state[5], AES_BLOCK_XOR(state[4], state[3]));
+        tmp = AES_BLOCK_XNOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
         AES_BLOCK_STORE(mac_multi_1, tmp);
         for (i = 0; i < 16; i++) {
             mac[i + 16] = mac_multi_1[i] ^ mac_multi_1[1 * 16 + i] ^ mac_multi_1[2 * 16 + i] ^
@@ -157,7 +163,7 @@ aegis256x4_squeeze_keystream(uint8_t *const dst, aes_block_t *const state)
 
     tmp = AES_BLOCK_XOR(state[5], state[4]);
     tmp = AES_BLOCK_XOR(tmp, state[1]);
-    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], state[3]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, tmp);
 }
 
@@ -171,7 +177,7 @@ aegis256x4_enc(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     tmp = AES_BLOCK_XOR(msg, state[5]);
     tmp = AES_BLOCK_XOR(tmp, state[4]);
     tmp = AES_BLOCK_XOR(tmp, state[1]);
-    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], state[3]));
+    tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, tmp);
 
     aegis256x4_update(state, msg);
@@ -186,7 +192,7 @@ aegis256x4_dec(uint8_t *const dst, const uint8_t *const src, aes_block_t *const 
     msg = AES_BLOCK_XOR(msg, state[5]);
     msg = AES_BLOCK_XOR(msg, state[4]);
     msg = AES_BLOCK_XOR(msg, state[1]);
-    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], state[3]));
+    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(dst, msg);
 
     aegis256x4_update(state, msg);
@@ -206,7 +212,7 @@ aegis256x4_declast(uint8_t *const dst, const uint8_t *const src, size_t len,
     msg = AES_BLOCK_XOR(msg, state[5]);
     msg = AES_BLOCK_XOR(msg, state[4]);
     msg = AES_BLOCK_XOR(msg, state[1]);
-    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], state[3]));
+    msg = AES_BLOCK_XOR(msg, AES_BLOCK_AND(state[2], AES_BLOCK_NOT(state[3])));
     AES_BLOCK_STORE(pad, msg);
 
     memset(pad + len, 0, sizeof pad - len);
@@ -227,7 +233,7 @@ aegis256x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
     const int   d = AES_BLOCK_LENGTH / 16;
 
     tmp = AES_BLOCK_LOAD_64x2(maclen << 3, adlen << 3);
-    tmp = AES_BLOCK_XOR(tmp, state[3]);
+    tmp = AES_BLOCK_XNOR(tmp, state[3]);
 
     for (i = 0; i < 7; i++) {
         aegis256x4_update(state, tmp);
@@ -237,7 +243,7 @@ aegis256x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
     if (maclen == 16) {
 #if AES_BLOCK_LENGTH > 16
         tmp = AES_BLOCK_XOR(state[5], state[4]);
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
 
@@ -246,13 +252,13 @@ aegis256x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
             aegis256x4_absorb(r, state);
         }
         tmp = AES_BLOCK_LOAD_64x2(maclen << 3, d);
-        tmp = AES_BLOCK_XOR(tmp, state[3]);
+        tmp = AES_BLOCK_XNOR(tmp, state[3]);
         for (i = 0; i < 7; i++) {
             aegis256x4_update(state, tmp);
         }
 #endif
         tmp = AES_BLOCK_XOR(state[5], state[4]);
-        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[3], state[2]));
+        tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XNOR(state[3], state[2]));
         tmp = AES_BLOCK_XOR(tmp, AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
@@ -260,7 +266,7 @@ aegis256x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
 #if AES_BLOCK_LENGTH > 16
         tmp = AES_BLOCK_XOR(state[2], AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
-        tmp = AES_BLOCK_XOR(state[5], AES_BLOCK_XOR(state[4], state[3]));
+        tmp = AES_BLOCK_XNOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
         AES_BLOCK_STORE(t + AES_BLOCK_LENGTH, tmp);
         for (i = 1; i < d; i++) {
             memcpy(r, t + i * 16, 16);
@@ -269,7 +275,7 @@ aegis256x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
             aegis256x4_absorb(r, state);
         }
         tmp = AES_BLOCK_LOAD_64x2(maclen << 3, d);
-        tmp = AES_BLOCK_XOR(tmp, state[3]);
+        tmp = AES_BLOCK_XNOR(tmp, state[3]);
         for (i = 0; i < 7; i++) {
             aegis256x4_update(state, tmp);
         }
@@ -277,7 +283,7 @@ aegis256x4_mac_nr(uint8_t *mac, size_t maclen, uint64_t adlen, aes_block_t *stat
         tmp = AES_BLOCK_XOR(state[2], AES_BLOCK_XOR(state[1], state[0]));
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac, t, 16);
-        tmp = AES_BLOCK_XOR(state[5], AES_BLOCK_XOR(state[4], state[3]));
+        tmp = AES_BLOCK_XNOR(AES_BLOCK_XOR(state[5], state[4]), state[3]);
         AES_BLOCK_STORE(t, tmp);
         memcpy(mac + 16, t, 16);
     } else {

--- a/src/aegis256x4/aegis256x4_neon_sha3.c
+++ b/src/aegis256x4/aegis256x4_neon_sha3.c
@@ -1,0 +1,191 @@
+#if defined(__aarch64__) || defined(_M_ARM64)
+
+#    include <stddef.h>
+#    include <stdint.h>
+
+#    include "../common/common.h"
+#    include "aegis256x4.h"
+#    include "aegis256x4_neon_sha3.h"
+
+#    ifndef __ARM_FEATURE_CRYPTO
+#        define __ARM_FEATURE_CRYPTO 1
+#    endif
+#    ifndef __ARM_FEATURE_AES
+#        define __ARM_FEATURE_AES 1
+#    endif
+#    ifndef __ARM_FEATURE_SHA3
+#        define __ARM_FEATURE_SHA3 1
+#    endif
+
+#    include <arm_neon.h>
+
+#    ifdef __clang__
+#        pragma clang attribute push(__attribute__((target("neon,crypto,aes,sha3"))), \
+                                     apply_to = function)
+#    elif defined(__GNUC__)
+#        if __GNUC__ < 14
+#            pragma GCC target("arch=armv8.2-a+simd+crypto+sha3")
+#        else
+#            pragma GCC target("+simd+crypto+sha3")
+#        endif
+#    endif
+
+#    define AES_BLOCK_LENGTH 64
+#    define AES_INVERT_STATE3 1
+
+typedef struct {
+    uint8x16_t b0;
+    uint8x16_t b1;
+    uint8x16_t b2;
+    uint8x16_t b3;
+} aes_block_t;
+
+static const uint8_t ones_arr[] = { 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU,
+                                    0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU, 0xffU };
+
+static inline uint8x16x2_t
+fresh_ones_pair(void)
+{
+    // The AESE instruction first operand register is both an input and output
+    // to the instruction. If the first operand is used in multiple places,
+    // this can therefore force compilers to emit MOV instructions to duplicate
+    // the value. In AES_ENC0 we use a zero register which would ordinarily
+    // have this problem since the compiler can merge the zero constants
+    // together and reuse them, however compilers typically treat this as a
+    // special case since materializing zero is a zero-cost instruction on many
+    // micro-architectures. For AES_ENC1 we cannot use this trick:
+    // materializing 0xFF is not usually zero-cost so compilers do not treat it
+    // specially, however since this region of the code is so heavy in vector
+    // arithmetic, inserting an additional load instruction here is
+    // effectively free.
+    uint8x16x2_t ret;
+    __asm volatile("ldp %q0, %q1, [%2]": "=w"(ret.val[0]), "=w"(ret.val[1]): "r"(ones_arr));
+    return ret;
+}
+
+static inline aes_block_t
+AES_BLOCK_NOT(const aes_block_t a)
+{
+    return (aes_block_t) { vmvnq_u8(a.b0), vmvnq_u8(a.b1), vmvnq_u8(a.b2), vmvnq_u8(a.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { veorq_u8(a.b0, b.b0), veorq_u8(a.b1, b.b1), veorq_u8(a.b2, b.b2),
+                           veorq_u8(a.b3, b.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XNOR(const aes_block_t a, const aes_block_t b)
+{
+    const uint8x16_t ones = vmovq_n_u8(0xff);
+
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, ones), veor3q_u8(a.b1, b.b1, ones),
+                           veor3q_u8(a.b2, b.b2, ones), veor3q_u8(a.b3, b.b3, ones) };
+}
+
+static inline aes_block_t
+AES_BLOCK_XOR3(const aes_block_t a, const aes_block_t b, const aes_block_t c)
+{
+    return (aes_block_t) { veor3q_u8(a.b0, b.b0, c.b0), veor3q_u8(a.b1, b.b1, c.b1),
+                           veor3q_u8(a.b2, b.b2, c.b2), veor3q_u8(a.b3, b.b3, c.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_AND(const aes_block_t a, const aes_block_t b)
+{
+    return (aes_block_t) { vandq_u8(a.b0, b.b0), vandq_u8(a.b1, b.b1), vandq_u8(a.b2, b.b2),
+                           vandq_u8(a.b3, b.b3) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD(const uint8_t *a)
+{
+    return (aes_block_t) { vld1q_u8(a), vld1q_u8(a + 16), vld1q_u8(a + 32), vld1q_u8(a + 48) };
+}
+
+static inline aes_block_t
+AES_BLOCK_LOAD_64x2(uint64_t a, uint64_t b)
+{
+    const uint8x16_t t = vreinterpretq_u8_u64(vsetq_lane_u64((a), vmovq_n_u64(b), 1));
+    return (aes_block_t) { t, t, t, t };
+}
+
+static inline void
+AES_BLOCK_STORE(uint8_t *a, const aes_block_t b)
+{
+    vst1q_u8(a, b.b0);
+    vst1q_u8(a + 16, b.b1);
+    vst1q_u8(a + 32, b.b2);
+    vst1q_u8(a + 48, b.b3);
+}
+
+static inline aes_block_t
+AES_ENC0(const aes_block_t a)
+{
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b0)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b1)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b2)),
+                           vaesmcq_u8(vaeseq_u8(vmovq_n_u8(0), a.b3)) };
+}
+
+static inline aes_block_t
+AES_ENC1(const aes_block_t a)
+{
+    uint8x16x2_t ones01 = fresh_ones_pair();
+    uint8x16x2_t ones23 = fresh_ones_pair();
+    return (aes_block_t) { vaesmcq_u8(vaeseq_u8(ones01.val[0], a.b0)),
+                           vaesmcq_u8(vaeseq_u8(ones01.val[1], a.b1)),
+                           vaesmcq_u8(vaeseq_u8(ones23.val[0], a.b2)),
+                           vaesmcq_u8(vaeseq_u8(ones23.val[1], a.b3)) };
+}
+
+static inline aes_block_t
+AES_ENC(const aes_block_t a, const aes_block_t b)
+{
+    return AES_BLOCK_XOR(AES_ENC0(a), b);
+}
+
+static inline void
+aegis256x4_update(aes_block_t *const state, const aes_block_t d)
+{
+    aes_block_t tmp = state[5];
+
+    // Apply bitwise-NOT to state[3] to allow us to use the Arm SHA3 BCAX
+    // instruction.
+    state[5] = AES_BLOCK_XOR(AES_ENC0(state[4]), state[5]);
+    state[4] = AES_BLOCK_XOR(AES_ENC1(state[3]), state[4]);
+    state[3] = AES_BLOCK_XOR(AES_ENC0(state[2]), state[3]);
+    state[2] = AES_BLOCK_XOR(AES_ENC0(state[1]), state[2]);
+    state[1] = AES_BLOCK_XOR(AES_ENC0(state[0]), state[1]);
+    state[0] = AES_BLOCK_XOR3(AES_ENC0(tmp), state[0], d);
+}
+
+#    include "aegis256x4_common.h"
+
+struct aegis256x4_implementation aegis256x4_neon_sha3_implementation = {
+    .encrypt_detached        = encrypt_detached,
+    .decrypt_detached        = decrypt_detached,
+    .encrypt_unauthenticated = encrypt_unauthenticated,
+    .decrypt_unauthenticated = decrypt_unauthenticated,
+    .stream                  = stream,
+    .state_init              = state_init,
+    .state_encrypt_update    = state_encrypt_update,
+    .state_encrypt_final     = state_encrypt_final,
+    .state_decrypt_update    = state_decrypt_update,
+    .state_decrypt_final     = state_decrypt_final,
+    .state_mac_init          = state_mac_init,
+    .state_mac_update        = state_mac_update,
+    .state_mac_final         = state_mac_final,
+    .state_mac_reset         = state_mac_reset,
+    .state_mac_clone         = state_mac_clone,
+};
+
+#    ifdef __clang__
+#        pragma clang attribute pop
+#    endif
+
+#endif

--- a/src/aegis256x4/aegis256x4_neon_sha3.h
+++ b/src/aegis256x4/aegis256x4_neon_sha3.h
@@ -1,0 +1,9 @@
+#ifndef aegis256x4_neon_sha3_H
+#define aegis256x4_neon_sha3_H
+
+#include "../common/common.h"
+#include "implementations.h"
+
+extern struct aegis256x4_implementation aegis256x4_neon_sha3_implementation;
+
+#endif

--- a/src/aegis256x4/implementations.h
+++ b/src/aegis256x4/implementations.h
@@ -7,12 +7,13 @@
 #include "aegis256x4.h"
 
 /* Namespacing to avoid conflicts with libsodium */
-#define aegis256x4_soft_implementation     libaegis_aegis256x4_soft_implementation
-#define aegis256x4_aesni_implementation    libaegis_aegis256x4_aesni_implementation
-#define aegis256x4_neon_aes_implementation libaegis_aegis256x4_neon_aes_implementation
-#define aegis256x4_altivec_implementation  libaegis_aegis256x4_altivec_implementation
-#define aegis256x4_avx2_implementation     libaegis_aegis256x4_avx2_implementation
-#define aegis256x4_avx512_implementation   libaegis_aegis256x4_avx512_implementation
+#define aegis256x4_soft_implementation      libaegis_aegis256x4_soft_implementation
+#define aegis256x4_aesni_implementation     libaegis_aegis256x4_aesni_implementation
+#define aegis256x4_neon_aes_implementation  libaegis_aegis256x4_neon_aes_implementation
+#define aegis256x4_neon_sha3_implementation libaegis_aegis256x4_neon_sha3_implementation
+#define aegis256x4_altivec_implementation   libaegis_aegis256x4_altivec_implementation
+#define aegis256x4_avx2_implementation      libaegis_aegis256x4_avx2_implementation
+#define aegis256x4_avx512_implementation    libaegis_aegis256x4_avx512_implementation
 
 typedef struct aegis256x4_implementation {
     int (*encrypt_detached)(uint8_t *c, uint8_t *mac, size_t maclen, const uint8_t *m, size_t mlen,


### PR DESCRIPTION
There is already an existing implementation of AEGIS-128L using the Neon SHA3 extension, but all other implementations are currently absent.

Add implementations for all of the non-128L code paths, mirroring the same approach throughout. This includes the BCAX trick (see PR #31) of bitwise-negating `state[3]` (and `state[7]` where relevant).

Benchmarking this on a range of Arm Neoverse platforms with LLVM 22, we see 1-33% speedups depending on the micro-architecture and code path being used.