### PR TITLE
Fix HAVE_ANDROID_GETCPUFEATURES for modern Android (API >= 18)

### DIFF
--- a/src/common/common.h
+++ b/src/common/common.h
@@ -24,8 +24,10 @@ static int errno;
 #ifdef __ANDROID_API__
 #    if __ANDROID_API__ < 18
 #        undef HAVE_GETAUXVAL
+// Only use the legacy cpu-features.h on very old Android (< API 18)
+// where getauxval is not available. Modern Android uses getauxval/AT_HWCAP.
+#        define HAVE_ANDROID_GETCPUFEATURES
 #    endif
-#    define HAVE_ANDROID_GETCPUFEATURES
 #endif
 #if defined(__i386__) || defined(_M_IX86) || defined(__x86_64__) || defined(_M_AMD64)
 #    define HAVE_CPUID


### PR DESCRIPTION
## Problem

`HAVE_ANDROID_GETCPUFEATURES` is currently defined for all Android API levels, which triggers `#include <cpu-features.h>` in `cpu.c`. This header was deprecated by Google and is no longer shipped in current NDK versions (r23+), causing compilation failures when building for Android targets.

Modern Android (API ≥ 18) already has `getauxval`/`AT_HWCAP` available, and the existing code already supports that path via `HAVE_GETAUXVAL` — it just never gets used because `HAVE_ANDROID_GETCPUFEATURES` takes precedence in the `#elif` chain in `cpu.c`.

## Fix

Move `#define HAVE_ANDROID_GETCPUFEATURES` inside the existing `__ANDROID_API__ < 18` guard, so:

- **API < 18**: uses `cpu-features.h` (legacy path, unchanged)
- **API ≥ 18**: uses `getauxval`/`AT_HWCAP` (already implemented, now actually reachable)

## Impact

No behavior change for non-Android targets. No behavior change for Android API < 18. Fixes compilation with modern NDK and enables proper runtime CPU feature detection (NEON, AES, SHA3) on modern Android via the `getauxval` path that was already written but unreachable.
